### PR TITLE
Allow Zigbee Rejoin Timeout to be configured via Kconfig

### DIFF
--- a/docs/lib/images/zigbee_signal_handler_10_rejoin.svg
+++ b/docs/lib/images/zigbee_signal_handler_10_rejoin.svg
@@ -45,7 +45,7 @@
 			<desc>Schedule stop_network_rejoin(ZB_TRUE) after ZB_DEV_REJOIN_TIM...</desc>
 			<rect x="0" y="505.641" width="147.827" height="59.45" class="st1"/>
 			<text x="55.5" y="519.17" class="st2">Schedule <tspan x="9.8" dy="1.2em" class="st5">stop_network_rejoin(ZB_TRUE) </tspan><tspan
-						x="64.09" dy="1.2em" class="st5">after </tspan><tspan x="10.05" dy="1.38em" class="st5">ZB_DEV_REJOIN_TIMEOUT_MS</tspan></text>		</g>
+						x="64.09" dy="1.2em" class="st5">after </tspan><tspan x="10.05" dy="1.38em" class="st5">CONFIG_ZIGBEE_DEV_REJOIN_TIMEOUT_MS</tspan></text>		</g>
 		<g id="shape1423-16" transform="translate(135.547,-258.052)">
 			<title>Hexagon.1423</title>
 			<desc>role == end device</desc>

--- a/docs/lib/zigbee_app_utils.rst
+++ b/docs/lib/zigbee_app_utils.rst
@@ -308,7 +308,7 @@ The rejoin procedure is different for routers and end devices in the following a
   * The procedure to join or rejoin the network can be restarted by calling :c:func:`user_input_indicate`, but it needs to be implemented in the application (for example, by calling :c:func:`user_input_indicate` when a button is pressed).
     The procedure is restarted only if the device was unable to join and the procedure is not running.
 
-  For the end device, the application alarm is scheduled with ``stop_network_rejoin(ZB_TRUE)``, to be called after the amount of time specified in ``ZB_DEV_REJOIN_TIMEOUT_MS``.
+  For the end device, the application alarm is scheduled with ``stop_network_rejoin(ZB_TRUE)``, to be called after the amount of time specified in ``CONFIG_ZIGBEE_DEV_REJOIN_TIMEOUT_MS``.
 
   If :c:func:`stop_network_rejoin` is called with ``was_scheduled`` set to ``ZB_TRUE``, :c:func:`user_input_indicate` can restart the rejoin procedure.
   :c:func:`user_input_indicate` restarts the rejoin procedure if the device did not join the network and is not trying to join a network.
@@ -479,6 +479,10 @@ Factory reset button
 Trust Center Rejoin
     To enable the Trust Center Rejoin feature, use the ``CONFIG_ZIGBEE_TC_REJOIN_ENABLED`` Kconfig option.
     This option is enabled by default.
+
+Rejoin Timeout
+    To adjust maximum timeout for when an end device is attempting to join or rejoin a network, use the ``CONFIG_ZIGBEE_DEV_REJOIN_TIMEOUT_MS`` Kconfig option.
+    This option is set to 200 seconds by default.
 
 For detailed steps about configuring the library in a Zigbee sample or application, see :ref:`ug_zigbee_configuring_components_application_utilities`.
 

--- a/subsys/Kconfig
+++ b/subsys/Kconfig
@@ -379,6 +379,10 @@ config ZIGBEE_TC_REJOIN_ENABLED
 	bool "Enables Trust Center Rejoin"
 	default y
 
+config ZIGBEE_DEV_REJOIN_TIMEOUT_MS
+	int "Timeout in ms after which End Device stops to send beacons if can not join/rejoin a network"
+	default 200000
+
 DT_CHOSEN_NCS_ZIGBEE_TIMER := ncs,zigbee-timer
 
 choice ZIGBEE_TIME_SOURCE

--- a/subsys/lib/zigbee_app_utils/zigbee_app_utils.c
+++ b/subsys/lib/zigbee_app_utils/zigbee_app_utils.c
@@ -20,13 +20,6 @@
 /* Number of retries until the pin value stabilizes. */
 #define READ_RETRIES  10
 
-/* Timeout after which End Device stops to send beacons
- * if can not join/rejoin a network.
- */
-#ifndef ZB_DEV_REJOIN_TIMEOUT_MS
-#define ZB_DEV_REJOIN_TIMEOUT_MS (1000 * 200)
-#endif
-
 /* Maximum interval between join/rejoin attempts. */
 #define REJOIN_INTERVAL_MAX_S    (15 * 60)
 
@@ -823,7 +816,7 @@ static void rejoin_the_network(zb_uint8_t param)
  *        is not running, device is not joined and device is not waiting
  *        for the user input, start rejoin procedure. Additionally,
  *        schedule alarm to stop rejoin procedure after the timeout
- *        defined by ZB_DEV_REJOIN_TIMEOUT_MS.
+ *        defined by CONFIG_ZIGBEE_DEV_REJOIN_TIMEOUT_MS.
  */
 static void start_network_rejoin(void)
 {
@@ -848,7 +841,7 @@ static void start_network_rejoin(void)
 				stop_network_rejoin,
 				ZB_TRUE,
 				ZB_MILLISECONDS_TO_BEACON_INTERVAL(
-					ZB_DEV_REJOIN_TIMEOUT_MS));
+					CONFIG_ZIGBEE_DEV_REJOIN_TIMEOUT_MS));
 			ZB_ERROR_CHECK(zb_err_code);
 #endif
 


### PR DESCRIPTION
We have found it to be useful to adjust the value of `ZB_DEV_REJOIN_TIMEOUT_MS` depending on the device type / network coordinator to improve device resilience e.g. at long distances or during power failures. We believe it makes sense for this timeout to be configurable via Kconfig, rather than hidden away in `zigbee_app_utils.c` since device developers should be aware of situations where the end device may disconnect and fail to rejoin until manually interacted with, if this timeout is breached.

It was previously overridable with an `#ifndef` guard, but it is not clear how developers are expected to overwrite this definition without modifying the SDK or manually adding the build flag. Moving it to Kconfig seems to be much more straight forward for an option that is likely important to device developers.