### PR TITLE
Using __buildin_offsetof when building with clang

### DIFF
--- a/lib/zboss/include/zb_types.h
+++ b/lib/zboss/include/zb_types.h
@@ -599,7 +599,7 @@ zb_addr_u;
 #define ZB_INT32_C(c)  c ## L
 #define ZB_UINT32_C(c) c ## UL
 
-#if (defined __GNUC__) && (__GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6))
+#if ((defined __GNUC__) && (__GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6)) || defined __clang__)
 #define ZB_OFFSETOF(t, f) __builtin_offsetof(t,f)
 #else
 #define ZB_OFFSETOF(t, f) ((zb_size_t)(&((t *)NULL)->f))


### PR DESCRIPTION
to avoid compile-time errors in static_assert expressions since a fallback version of ZB_OFFSETOF basically does a reinterpret cast which is prohibited in the constexpr context

Error happens when trying to use clang as a compiler:
```
~/ncs/zigbee/ncs-zigbee/lib/zboss/include/zboss_api_buf.h:139:24: error: static assertion expression is not an integral constant expression
  139 | ZB_ASSERT_COMPILE_DECL((ZB_OFFSETOF(zb_mult_buf_t, buf) % sizeof(zb_uint32_t)) == 0);
      | ~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
~/ncs/zigbee/ncs-zigbee/lib/zboss/include/zb_debug.h:157:66: note: expanded from macro 'ZB_ASSERT_COMPILE_DECL'
  157 | #define ZB_ASSERT_COMPILE_DECL(expr) __extension__ static_assert(expr, "Assert at line __LINE__")
      |                                                                  ^~~~
~/ncs/zigbee/ncs-zigbee/lib/zboss/include/zboss_api_buf.h:139:25: note: cast that performs the conversions of a reinterpret_cast is not allowed in a co
nstant expression
  139 | ZB_ASSERT_COMPILE_DECL((ZB_OFFSETOF(zb_mult_buf_t, buf) % sizeof(zb_uint32_t)) == 0);
      | ~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
~/ncs/zigbee/ncs-zigbee/lib/zboss/include/zb_types.h:605:28: note: expanded from macro 'ZB_OFFSETOF'
  605 | #define ZB_OFFSETOF(t, f) ((zb_size_t)(&((t *)NULL)->f))
      |                            ^
~/ncs/zigbee/ncs-zigbee/lib/zboss/include/zb_debug.h:157:66: note: expanded from macro 'ZB_ASSERT_COMPILE_DECL'
  157 | #define ZB_ASSERT_COMPILE_DECL(expr) __extension__ static_assert(expr, "Assert at line __LINE__")
      |                                                                  ^~~~
1 error generated.

```

I wasn't able to find a version of clang when this builtin was introduced. I'm not sure it's needed tbh