### PR TITLE
samples: add low power snippet to Light Switch

### DIFF
--- a/samples/light_switch/Kconfig
+++ b/samples/light_switch/Kconfig
@@ -25,3 +25,10 @@ config LIGHT_SWITCH_TX_POWER
 	default 0
 	help
 		TX power level in dBm.
+
+config LIGHT_SWITCH_LOW_POWER
+	bool "Low power mode"
+	default n
+	help
+		Enable low power mode for the Light Switch sample.
+		This enables sleepy behavior and disables LEDs for power savings.

--- a/samples/light_switch/README.rst
+++ b/samples/light_switch/README.rst
@@ -58,7 +58,7 @@ The light switch supports the :ref:`zigbee_ug_sed` that enables the sleepy behav
    .. group-tab:: nRF54L15 DK
 
       To enable the sleepy behavior, press **Button 2** while the light switch sample is booting.
-   .. group-tab:: nRF52840 and nRF5340 DKs DK
+   .. group-tab:: nRF52840 and nRF5340 DKs
 
       To enable the sleepy behavior, press **Button 3** while the light switch sample is booting.
 
@@ -209,7 +209,7 @@ User interface
           The length of the button press can be edited using the ``CONFIG_FACTORY_RESET_PRESS_TIME_SECONDS`` Kconfig option from :ref:`lib_zigbee_application_utilities`.
           Releasing the button within this time does not trigger the factory reset procedure.
 
-   .. group-tab:: nRF52840 and nRF5340 DKs DK
+   .. group-tab:: nRF52840 and nRF5340 DKs
 
       LED 3:
           Lit and solid when the device is connected to a Zigbee network.
@@ -248,7 +248,7 @@ FOTA behavior assignments
          Indicates the OTA activity.
          Used only if the FOTA support is enabled.
 
-   .. group-tab:: nRF52840 and nRF5340 DKs DK
+   .. group-tab:: nRF52840 and nRF5340 DKs
 
       LED 2:
          Indicates the OTA activity.
@@ -264,7 +264,7 @@ Sleepy End Device behavior assignments
       Button 2:
           When pressed while resetting the kit, enables the :ref:`zigbee_ug_sed`.
 
-   .. group-tab:: nRF52840 and nRF5340 DKs DK
+   .. group-tab:: nRF52840 and nRF5340 DKs
 
       Button 3:
           When pressed while resetting the kit, enables the :ref:`zigbee_ug_sed`.
@@ -280,7 +280,7 @@ Multiprotocol Bluetooth LE extension assignments
           Lit and solid when a Bluetooth LE Central is connected to the NUS service.
           Available when using `Nordic UART Service (NUS)`_ in the multiprotocol configuration.
 
-   .. group-tab:: nRF52840 and nRF5340 DKs DK
+   .. group-tab:: nRF52840 and nRF5340 DKs
 
       LED 1:
           Lit and solid when a Bluetooth LE Central is connected to the NUS service.
@@ -337,7 +337,7 @@ After programming the sample to your development kits, complete the following st
 
          This LED indicates that the light switch found a light bulb to control.
 
-   .. group-tab:: nRF52840 and nRF5340 DKs DK
+   .. group-tab:: nRF52840 and nRF5340 DKs
 
       1. Turn on the development kit that runs the Network coordinator sample.
 
@@ -414,7 +414,7 @@ Set up nRF Toolbox by completing the following steps:
 	  
          Observe that **LED 0** on the light switch node is solid.
 
-      .. group-tab:: nRF52840 and nRF5340 DKs DK
+      .. group-tab:: nRF52840 and nRF5340 DKs
 	  
          Observe that **LED 1** on the light switch node is solid.   
 

--- a/samples/light_switch/README.rst
+++ b/samples/light_switch/README.rst
@@ -145,6 +145,24 @@ For more information about configuration files in the |NCS|, see `Build and conf
 
   .. include:: /includes/sample_fem_support.txt
 
+Snippets
+========
+
+.. |snippet| replace:: :makevar:`light_switch_SNIPPET`
+
+The following snippets are available:
+
+* ``low_power`` - Enables low power consumption mode for the Light Switch sample.
+  This snippet disables serial communication, console output, enables sleepy end device behavior,
+  and disables LED indications to minimize power consumption.
+
+  To build with the low power snippet, use the following command:
+
+  .. parsed-literal::
+     :class: highlight
+
+     west build samples/light_switch -b *board_target* -- --snippet=low_power
+
 Configurable transmission power
 ===============================
 

--- a/samples/light_switch/sample.yaml
+++ b/samples/light_switch/sample.yaml
@@ -93,3 +93,23 @@ tests:
       - smoke
       - sysbuild
       - ci_samples_zigbee
+  sample.zigbee.light_switch.low_power:
+    sysbuild: true
+    build_only: true
+    extra_args:
+      - light_switch_SNIPPET="low_power"
+    integration_platforms:
+      - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54l15dk/nrf54l10/cpuapp
+      - nrf52840dk/nrf52840
+      - nrf5340dk/nrf5340/cpuapp
+    platform_allow:
+      - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54l15dk/nrf54l10/cpuapp
+      - nrf52840dk/nrf52840
+      - nrf5340dk/nrf5340/cpuapp
+    tags:
+      - ci_build
+      - smoke
+      - sysbuild
+      - ci_samples_zigbee

--- a/samples/light_switch/snippets/low_power/low_power.conf
+++ b/samples/light_switch/snippets/low_power/low_power.conf
@@ -1,0 +1,24 @@
+#
+# Copyright (c) 2025 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+# Low power configuration for Zigbee Light Switch
+CONFIG_LIGHT_SWITCH_LOW_POWER=y
+
+# Disable serial and console for power savings
+CONFIG_SERIAL=n
+CONFIG_CONSOLE=n
+
+# Disable logging for additional power savings
+CONFIG_LOG=n
+
+# Set TX power to 0 dBm
+CONFIG_LIGHT_SWITCH_TX_POWER=0
+
+# Enable device power management for low power consumption
+CONFIG_PM_DEVICE=y
+
+# Ensure RAM power down is enabled for low power consumption
+CONFIG_RAM_POWER_DOWN_LIBRARY=y

--- a/samples/light_switch/snippets/low_power/snippet.yml
+++ b/samples/light_switch/snippets/low_power/snippet.yml
@@ -1,0 +1,9 @@
+#
+# Copyright (c) 2025 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+name: low_power
+append:
+  EXTRA_CONF_FILE: low_power.conf

--- a/samples/ncp/README.rst
+++ b/samples/ncp/README.rst
@@ -83,7 +83,7 @@ The communication channel uses Zephyr's `UART API`_.
 
       The ``uart20`` pins are configured by devicetree overlay files for each supported development kit in the :file:`boards` directory.
 
-   .. group-tab:: nRF52840 and nRF5340 DKs DK
+   .. group-tab:: nRF52840 and nRF5340 DKs
 
       The serial device is selected in devicetree like this:
 
@@ -288,7 +288,7 @@ User interface
    .. group-tab:: nRF54L15 DK
 
 	  All the NCP sample's interactions with the application are automatically handled using serial communication.
-   .. group-tab:: nRF52840 and nRF5340 DKs DK
+   .. group-tab:: nRF52840 and nRF5340 DKs
 
 	  All the NCP sample’s interactions with the application are automatically handled using serial or USB communication.
 
@@ -333,7 +333,7 @@ After building the sample and programming it to your development kit, complete t
 	  When it is found, the simple gateway configures bindings and reporting for the device.
 	  It then starts sending On/Off toggle commands with a 15-second interval that toggle the **LED 1** on the light bulb on and off.
 
-   .. group-tab:: nRF52840 and nRF5340 DKs DK
+   .. group-tab:: nRF52840 and nRF5340 DKs
 
 	  1. Download and extract the `ZBOSS NCP Host`_ package.
 

--- a/samples/network_coordinator/README.rst
+++ b/samples/network_coordinator/README.rst
@@ -82,7 +82,7 @@ User interface
             The length of the button press can be edited using the ``CONFIG_FACTORY_RESET_PRESS_TIME_SECONDS`` Kconfig option from :ref:`lib_zigbee_application_utilities`.
             Releasing the button within this time does not trigger the factory reset procedure.
 
-   .. group-tab:: nRF52840 and nRF5340 DKs DK
+   .. group-tab:: nRF52840 and nRF5340 DKs
 
       LED 1:
           Blinks to indicate that the main application thread is running.
@@ -151,7 +151,7 @@ After programming the sample to your development kit, complete the following ste
          #. Use buttons on the development kit that runs the Light switch sample to control the light bulb, as described in the Light switch sample's user interface section.
 
             The result of using the buttons is reflected on the light bulb's **LED 1**.
-   .. group-tab:: nRF52840 and nRF5340 DKs DK
+   .. group-tab:: nRF52840 and nRF5340 DKs
 
       1. Turn on the development kit that runs the coordinator sample.
 

--- a/samples/shell/README.rst
+++ b/samples/shell/README.rst
@@ -82,7 +82,7 @@ User interface
 
       Button 3:
           Starts or cancels the Identify mode.
-   .. group-tab:: nRF52840 and nRF5340 DKs DK
+   .. group-tab:: nRF52840 and nRF5340 DKs
 
       LED 3:
           Turns on when the device joins the network.
@@ -92,7 +92,7 @@ User interface
 
       Button 4:
           Starts or cancels the Identify mode.
-   .. group-tab:: nRF52840 and nRF5340 DKs Dongle
+   .. group-tab:: nRF52840 Dongle
 
       LED 1:
           Blinks green to indicate that the identification mode is on.

--- a/samples/template/README.rst
+++ b/samples/template/README.rst
@@ -63,7 +63,7 @@ User interface
          * If pressed for five seconds, it initiates the `factory reset of the device <Resetting to factory defaults_>`_.
            The length of the button press can be edited using the ``CONFIG_FACTORY_RESET_PRESS_TIME_SECONDS`` Kconfig option from :ref:`lib_zigbee_application_utilities`.
            Releasing the button within this time does not trigger the factory reset procedure.
-   .. group-tab:: nRF52840 and nRF5340 DKs DK
+   .. group-tab:: nRF52840 and nRF5340 DKs
 
      LED 3:
          Turns on when the device joins the network.
@@ -108,7 +108,7 @@ After programming the sample to your development kit, complete the following ste
 
          .. note::
               If **LED 2** does not turn on, press **Button 0** on the Coordinator to reopen the network.
-   .. group-tab:: nRF52840 and nRF5340 DKs DK
+   .. group-tab:: nRF52840 and nRF5340 DKs
    
       1. Turn on the development kit that runs the Network coordinator sample.
 


### PR DESCRIPTION
Add low_power snippet that disables serial/console/logging, enables sleepy behavior, disables LEDs, and optimizes power consumption.

Usage: west build samples/light_switch -b <board> --snippet=low_power