### PR TITLE
docs: Removed mentioning experimental support for RC23

### DIFF
--- a/docs/setup.rst
+++ b/docs/setup.rst
@@ -3,7 +3,7 @@
 Requirements and setup
 ######################
 
-This page outlines the requirements that you need to meet before you start working with the experimental support release of |addon| and Zigbee R23 protocol.
+This page outlines the requirements that you need to meet before you start working with the |addon| and Zigbee R23 protocol.
 
 Hardware requirements
 *********************


### PR DESCRIPTION
The documentation has a leftover that calls support for R23 as experimental. Removed mentioning the status at all, as it is error prone.