### PR TITLE
Added support for DFU over Bluetooth LE SMP

### DIFF
--- a/include/zigbee/zigbee_bt_dfu.h
+++ b/include/zigbee/zigbee_bt_dfu.h
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/**
+ * @file zigbee_bt_dfu.h
+ *
+ * @brief DFU over Bluetooth LE SMP helpers for Zigbee applications.
+ */
+
+#ifndef ZIGBEE_BT_DFU_H_
+#define ZIGBEE_BT_DFU_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void zigbee_bt_dfu_init(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ZIGBEE_BT_DFU_H_ */

--- a/samples/light_switch/CMakeLists.txt
+++ b/samples/light_switch/CMakeLists.txt
@@ -31,7 +31,7 @@ if(CONFIG_CHIP)
 
 	target_sources(app PRIVATE
 		src/main.cpp
-		src/app_task.cpp
+		src/app_task_matter.cpp
 		src/app_task_zigbee.c
 		src/light_switch.cpp
 		src/shell_commands.cpp

--- a/samples/light_switch/Kconfig
+++ b/samples/light_switch/Kconfig
@@ -57,3 +57,10 @@ config LIGHT_SWITCH_LOW_POWER
 	help
 		Enable low power mode for the Light Switch sample.
 		This enables sleepy behavior and disables LEDs for power savings.
+
+if ZIGBEE_BT_DFU
+
+config BT_DEVICE_NAME
+	default "Zigbee_Switch"
+
+endif # ZIGBEE_BT_DFU

--- a/samples/light_switch/README.rst
+++ b/samples/light_switch/README.rst
@@ -151,7 +151,11 @@ Source file setup
 
 This sample is split into the following source files:
 
-* The :file:`main` file to handle initialization and light switch basic behavior.
+* The :file:`main` file is the application entry point only.
+* The :file:`app_task_zigbee` file manages the application task flow, user input handling, and Zigbee-specific startup and control logic.
+* The :file:`app_task_matter` file is used in the Matter extension build only.
+  It implements the application tasks flow: button input, timers, and delegating control actions to bound lighting devices.
+* The :file:`light_switch` file to implement the light switch application logic and interaction with Zigbee clusters.
 * An additional :file:`nus_cmd` file for handling NUS commands.
 
 .. _zigbee_light_switch_activating_variants:

--- a/samples/light_switch/include/app_task_matter.h
+++ b/samples/light_switch/include/app_task_matter.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Nordic Semiconductor ASA
+ * Copyright (c) 2026 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */

--- a/samples/light_switch/sample.yaml
+++ b/samples/light_switch/sample.yaml
@@ -35,6 +35,23 @@ tests:
       - smoke
       - sysbuild
       - ci_samples_zigbee
+  sample.zigbee.light_switch.matter.bt_dfu:
+    sysbuild: true
+    build_only: true
+    extra_args:
+      - FILE_SUFFIX=matter_fota
+      - CONFIG_CHIP_DFU_OVER_BT_SMP=y
+    integration_platforms:
+      - nrf54lm20dk/nrf54lm20a/cpuapp
+      - nrf54lm20dk/nrf54lm20b/cpuapp
+    platform_allow:
+      - nrf54lm20dk/nrf54lm20a/cpuapp
+      - nrf54lm20dk/nrf54lm20b/cpuapp
+    tags:
+      - ci_build
+      - smoke
+      - sysbuild
+      - ci_samples_zigbee
   sample.zigbee.light_switch:
     sysbuild: true
     build_only: true
@@ -143,6 +160,31 @@ tests:
     platform_allow:
       - nrf5340dk/nrf5340/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
+    tags:
+      - ci_build
+      - smoke
+      - sysbuild
+      - ci_samples_zigbee
+  sample.zigbee.light_switch.fota_and_bt_dfu:
+    sysbuild: true
+    build_only: true
+    extra_args:
+      - FILE_SUFFIX=fota
+      - CONFIG_ZIGBEE_BT_DFU=y
+    integration_platforms:
+      - nrf52840dk/nrf52840
+      - nrf5340dk/nrf5340/cpuapp
+      - nrf54l15dk/nrf54l10/cpuapp
+      - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54lm20dk/nrf54lm20a/cpuapp
+      - nrf54lm20dk/nrf54lm20b/cpuapp
+    platform_allow:
+      - nrf52840dk/nrf52840
+      - nrf5340dk/nrf5340/cpuapp
+      - nrf54l15dk/nrf54l10/cpuapp
+      - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54lm20dk/nrf54lm20a/cpuapp
+      - nrf54lm20dk/nrf54lm20b/cpuapp
     tags:
       - ci_build
       - smoke

--- a/samples/light_switch/src/app_task_matter.cpp
+++ b/samples/light_switch/src/app_task_matter.cpp
@@ -1,10 +1,10 @@
 /*
- * Copyright (c) 2022 Nordic Semiconductor ASA
+ * Copyright (c) 2026 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
-#include "app_task.h"
+#include "app_task_matter.h"
 
 #include "light_switch.h"
 

--- a/samples/light_switch/src/app_task_zigbee.c
+++ b/samples/light_switch/src/app_task_zigbee.c
@@ -38,11 +38,20 @@
 #if CONFIG_ZIGBEE_FOTA
 #include <zigbee/zigbee_fota.h>
 #include <zephyr/sys/reboot.h>
-#include <zephyr/dfu/mcuboot.h>
+#endif /* CONFIG_ZIGBEE_FOTA */
 
+#if defined(CONFIG_ZIGBEE_FOTA) || defined(CONFIG_ZIGBEE_BT_DFU)
+#include <zephyr/dfu/mcuboot.h>
+#endif
+
+#if CONFIG_ZIGBEE_FOTA
 /* LED indicating OTA Client Activity. */
 #define OTA_ACTIVITY_LED          DK_LED2
 #endif /* CONFIG_ZIGBEE_FOTA */
+
+#ifdef CONFIG_ZIGBEE_BT_DFU
+#include <zigbee/zigbee_bt_dfu.h>
+#endif
 
 #if CONFIG_BT_NUS
 #include "nus_cmd.h"
@@ -642,7 +651,7 @@ static void light_switch_button_handler(struct k_timer *timer)
 	}
 }
 
-#ifdef CONFIG_ZIGBEE_FOTA
+#if defined(CONFIG_ZIGBEE_FOTA) || defined(CONFIG_ZIGBEE_BT_DFU)
 static void confirm_image(void)
 {
 	if (!boot_is_img_confirmed()) {
@@ -655,7 +664,9 @@ static void confirm_image(void)
 		}
 	}
 }
+#endif
 
+#ifdef CONFIG_ZIGBEE_FOTA
 static void ota_evt_handler(const struct zigbee_fota_evt *evt)
 {
 	switch (evt->id) {
@@ -959,16 +970,22 @@ int ZigbeeStart(void)
 		power_down_unused_ram();
 	}
 
+#if defined(CONFIG_ZIGBEE_FOTA) || defined(CONFIG_ZIGBEE_BT_DFU)
+	/* Mark the current firmware as valid. */
+	confirm_image();
+#endif
+
 #ifdef CONFIG_ZIGBEE_FOTA
 	/* Initialize Zigbee FOTA download service. */
 	zigbee_fota_init(ota_evt_handler);
 
-	/* Mark the current firmware as valid. */
-	confirm_image();
-
 	/* Register callback for handling ZCL commands. */
 	ZB_ZCL_REGISTER_DEVICE_CB(zcl_device_cb);
 #endif /* CONFIG_ZIGBEE_FOTA */
+
+#ifdef CONFIG_ZIGBEE_BT_DFU
+	zigbee_bt_dfu_init();
+#endif
 
 	/* Register dimmer switch device context (endpoints). */
 	ZB_AF_REGISTER_DEVICE_CTX(&dimmer_switch_ctx);

--- a/samples/light_switch/src/main.cpp
+++ b/samples/light_switch/src/main.cpp
@@ -17,7 +17,7 @@
 
 #ifdef CONFIG_ZIGBEE_MATTER_COEXISTENCE
 
-#include "app_task.h"
+#include "app_task_matter.h"
 
 #include <zigbee/matter_coexistence.h>
 

--- a/subsys/lib/CMakeLists.txt
+++ b/subsys/lib/CMakeLists.txt
@@ -5,6 +5,7 @@
 #
 
 add_subdirectory_ifdef(CONFIG_ZIGBEE_FOTA zigbee_fota)
+add_subdirectory_ifdef(CONFIG_ZIGBEE_BT_DFU zigbee_bt_dfu)
 add_subdirectory_ifdef(CONFIG_ZIGBEE_APP_UTILS zigbee_app_utils)
 add_subdirectory_ifdef(CONFIG_ZIGBEE_LOGGER_EP zigbee_logger_ep)
 add_subdirectory_ifdef(CONFIG_ZIGBEE_MATTER_COEXISTENCE zigbee_matter_coexistence)

--- a/subsys/lib/Kconfig
+++ b/subsys/lib/Kconfig
@@ -6,6 +6,7 @@
 menu "Zigbee libraries"
 
 rsource "zigbee_fota/Kconfig"
+rsource "zigbee_bt_dfu/Kconfig"
 rsource "zigbee_app_utils/Kconfig"
 rsource "zigbee_logger_ep/Kconfig"
 rsource "zigbee_matter_coexistence/Kconfig"

--- a/subsys/lib/zigbee_bt_dfu/CMakeLists.txt
+++ b/subsys/lib/zigbee_bt_dfu/CMakeLists.txt
@@ -1,0 +1,10 @@
+#
+# Copyright (c) 2026 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+zephyr_library()
+zephyr_library_sources(zigbee_bt_dfu.c)
+
+zephyr_library_link_libraries(MCUBOOT_BOOTUTIL)

--- a/subsys/lib/zigbee_bt_dfu/Kconfig
+++ b/subsys/lib/zigbee_bt_dfu/Kconfig
@@ -1,0 +1,88 @@
+#
+# Copyright (c) 2026 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+config ZIGBEE_BT_DFU
+	bool "Enable DFU over Bluetooth LE SMP feature set"
+	depends on !CHIP
+	select BOOTLOADER_MCUBOOT
+	select BT
+	select BT_PERIPHERAL
+	select MCUMGR
+	select MCUMGR_TRANSPORT_BT
+	select IMG_MANAGER
+	select STREAM_FLASH
+	select ZCBOR
+	select MCUMGR_GRP_IMG
+	select MCUMGR_GRP_OS
+	select MCUMGR_GRP_IMG_STATUS_HOOKS
+	# Enable custom SMP request to erase settings partition.
+	select MCUMGR_GRP_ZBASIC
+	select MCUMGR_GRP_ZBASIC_STORAGE_ERASE
+	select MCUMGR_TRANSPORT_BT_REASSEMBLY
+	help
+	  Enables Device Firmware Upgrade over Bluetooth LE with SMP and configures
+	  the set of options related to that feature.
+
+	  Cannot be combined with Matter (CONFIG_CHIP), as it requires different Bluetooth LE orchestration.
+	  Use Matter's CONFIG_CHIP_DFU_OVER_BT_SMP instead.
+
+if ZIGBEE_BT_DFU
+
+config BT_MAX_CONN
+	default 1
+
+# MCU Manager and SMP configuration
+choice MCUMGR_TRANSPORT_BT_PERM
+	default MCUMGR_TRANSPORT_BT_PERM_RW
+endchoice
+		
+config MCUMGR_TRANSPORT_NETBUF_COUNT
+	default 6
+
+config MCUMGR_MGMT_NOTIFICATION_HOOKS
+	bool
+	default y
+		
+config MCUMGR_GRP_IMG_UPLOAD_CHECK_HOOK
+	bool
+	default y
+		
+config MCUMGR_SMP_COMMAND_STATUS_HOOKS
+	bool
+	default y
+		
+# Increase BT MTU and RX buffer sizes to improve DFU throughput
+config BT_L2CAP_TX_MTU
+	default 498
+		
+config BT_BUF_ACL_RX_SIZE
+	default 502
+		
+# Increase MCUMGR_TRANSPORT_NETBUF_SIZE, as it must be big enough to fit MAX MTU + overhead and for single-image DFU default is 384 B
+config MCUMGR_TRANSPORT_NETBUF_SIZE
+	default 1024
+		
+# Increase system workqueue size, as SMP is processed within it
+config SYSTEM_WORKQUEUE_STACK_SIZE
+	default 2800
+		
+if SOC_SERIES_NRF53
+		
+# Enable custom SMP request to erase settings partition.
+config MCUMGR_GRP_ZBASIC
+	default y
+		
+config MCUMGR_GRP_ZBASIC_STORAGE_ERASE
+	default y
+		
+endif # SOC_SERIES_NRF53
+
+module = ZIGBEE_BT_DFU
+module-str = Zigbee Bluetooth LE DFU
+source "${ZEPHYR_BASE}/subsys/logging/Kconfig.template.log_config"
+
+endif # ZIGBEE_BT_DFU
+

--- a/subsys/lib/zigbee_bt_dfu/zigbee_bt_dfu.c
+++ b/subsys/lib/zigbee_bt_dfu/zigbee_bt_dfu.c
@@ -1,0 +1,132 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include <zigbee/zigbee_bt_dfu.h>
+
+#if !defined(CONFIG_MCUMGR_TRANSPORT_BT)
+#error "DFU over SMP requires MCUmgr Bluetooth LE module config enabled"
+#endif
+
+#if (!defined(CONFIG_MCUMGR_GRP_IMG) || !defined(CONFIG_MCUMGR_GRP_OS))
+#error "DFU over SMP requires MCUmgr IMG and OS groups"
+#endif
+
+#include <zephyr/bluetooth/bluetooth.h>
+#include <zephyr/bluetooth/conn.h>
+#include <zephyr/dfu/mcuboot.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/mgmt/mcumgr/grp/img_mgmt/img_mgmt.h>
+#include <zephyr/mgmt/mcumgr/mgmt/callbacks.h>
+#include <zephyr/mgmt/mcumgr/mgmt/mgmt_defines.h>
+
+#define BT_ADV_INT_MIN 400
+#define BT_ADV_INT_MAX 500
+
+LOG_MODULE_REGISTER(zigbee_bt_dfu, CONFIG_ZIGBEE_BT_DFU_LOG_LEVEL);
+
+static struct k_work advertise_work;
+
+static enum mgmt_cb_return
+upload_confirm_handler(uint32_t event, enum mgmt_cb_return prev_status,
+                       int32_t *rc, uint16_t *group, bool *abort_more,
+                       void *data, size_t data_size) {
+  const struct img_mgmt_upload_check *img_data = data;
+
+  if (data == NULL) {
+    return MGMT_CB_OK;
+  }
+
+  LOG_INF("DFU over SMP progress: %d/%llu B of image %d", img_data->req->off,
+          img_data->action->size, img_data->req->image);
+
+  return MGMT_CB_OK;
+}
+
+static enum mgmt_cb_return command_handler(uint32_t event, enum mgmt_cb_return,
+                                           int32_t *, uint16_t *, bool *,
+                                           void *, size_t) {
+  return MGMT_CB_OK;
+}
+
+static enum mgmt_cb_return dfu_stopped_handler(uint32_t, enum mgmt_cb_return,
+                                               int32_t *, uint16_t *, bool *,
+                                               void *, size_t) {
+  return MGMT_CB_OK;
+}
+
+static struct mgmt_callback upload_confirm_callback = {
+    .callback = upload_confirm_handler,
+    .event_id = MGMT_EVT_OP_IMG_MGMT_DFU_CHUNK,
+};
+
+static struct mgmt_callback command_callback = {
+    .callback = command_handler,
+    .event_id = (MGMT_EVT_OP_CMD_RECV | MGMT_EVT_OP_CMD_DONE),
+};
+
+static struct mgmt_callback dfu_stopped_callback = {
+    .callback = dfu_stopped_handler,
+    .event_id =
+        (MGMT_EVT_OP_IMG_MGMT_DFU_STOPPED | MGMT_EVT_OP_IMG_MGMT_DFU_PENDING),
+};
+
+void zigbee_bt_dfu_disconnected(struct bt_conn *conn, uint8_t reason) {
+  LOG_INF("zigbee_bt_dfu_disconnected");
+
+  ARG_UNUSED(conn);
+  ARG_UNUSED(reason);
+
+  k_work_submit(&advertise_work);
+}
+
+BT_CONN_CB_DEFINE(conn_callbacks) = {
+    .disconnected = zigbee_bt_dfu_disconnected,
+};
+
+static const struct bt_data advertise_data[] = {
+    BT_DATA_BYTES(BT_DATA_FLAGS, (BT_LE_AD_GENERAL | BT_LE_AD_NO_BREDR)),
+    BT_DATA(BT_DATA_NAME_COMPLETE, CONFIG_BT_DEVICE_NAME,
+            sizeof(CONFIG_BT_DEVICE_NAME) - 1),
+};
+
+static const struct bt_data service_data[] = {
+    BT_DATA(BT_DATA_NAME_COMPLETE, CONFIG_BT_DEVICE_NAME,
+            sizeof(CONFIG_BT_DEVICE_NAME) - 1),
+};
+
+static void advertise(struct k_work *work) {
+  struct bt_le_adv_param params = BT_LE_ADV_PARAM_INIT(
+      BT_LE_ADV_OPT_CONN, BT_ADV_INT_MIN, BT_ADV_INT_MAX, NULL);
+  params.id = 0;
+
+  int result =
+      bt_le_adv_start(&params, advertise_data, ARRAY_SIZE(advertise_data),
+                      service_data, ARRAY_SIZE(service_data));
+
+  if (result != 0) {
+    LOG_ERR("Advertising failed to start (rc %d)", result);
+    return;
+  }
+
+  LOG_INF("Bluetooth LE advertising successfully started");
+}
+
+void zigbee_bt_dfu_init(void) {
+
+  mgmt_callback_register(&upload_confirm_callback);
+  mgmt_callback_register(&command_callback);
+  mgmt_callback_register(&dfu_stopped_callback);
+
+  k_work_init(&advertise_work, advertise);
+  int result = bt_enable(NULL);
+
+  if (result != 0) {
+    LOG_ERR("Bluetooth enable failed: %d", result);
+    return;
+  }
+
+  k_work_submit(&advertise_work);
+}


### PR DESCRIPTION
Created a new Kconfig module that provides support for DFU over BLuetooth LE for Zigbee-only solution.

What is still missing and have to be added:
* Module (mutex) for synchronizing Zigbee FOTA and DFU over BT
* Documentation
* Code alignments for light bulb sample