### PR TITLE
ci: Reduce CI time

### DIFF
--- a/.github/workflows/on_pr.yml
+++ b/.github/workflows/on_pr.yml
@@ -1,5 +1,5 @@
 name: Build zigbee samples on pr
-on: 
+on:
   pull_request:
     paths-ignore:
       - 'docs/**'
@@ -20,37 +20,98 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: zigbee-samples-${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+env:
+  CCACHE_DIR: ${{ github.workspace }}/.ccache
+  CCACHE_COMPILERCHECK: content
+  CCACHE_MAXSIZE: 2G
+  CCACHE_SLOPPINESS: file_macro,time_macros,include_file_mtime,include_file_ctime
+  WEST_PATH_CACHE: ${{ github.workspace }}/west-path-cache
+
 jobs:
   Build-samples:
     runs-on: ubuntu-24.04
     container: ghcr.io/nrfconnect/sdk-nrf-toolchain:v3.4.0-rc1
+    strategy:
+      fail-fast: false
+      matrix:
+        subset: [1, 2, 3, 4]
     defaults:
       run:
         # Bash shell is needed to set toolchain related environment variables in docker container
         # It is a workaround for GitHub Actions limitation https://github.com/actions/runner/issues/1964
         shell: bash
-    steps: 
+    steps:
     - name: Checkout repository code
       uses: actions/checkout@1e31de5234b9f8995739874a8ce0492dc87873e2 # v4
       with:
-        fetch-depth: 0
+        fetch-depth: 1
         path: zigbee
+
+    - name: Restore west module path cache
+      uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # v4
+      with:
+        path: west-path-cache
+        key: west-path-cache-${{ hashFiles('zigbee/west.yml') }}
+        restore-keys: |
+          west-path-cache-
+
+    - name: Restore ccache
+      uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # v4
+      with:
+        path: .ccache
+        key: ccache-zigbee-${{ hashFiles('zigbee/west.yml') }}-${{ github.base_ref }}
+        restore-keys: |
+          ccache-zigbee-${{ hashFiles('zigbee/west.yml') }}-
+          ccache-zigbee-
+
+    - name: Restore pip cache
+      uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # v4
+      with:
+        path: ~/.cache/pip
+        key: pip-zigbee-${{ hashFiles('zigbee/west.yml') }}
+
     - name: prepare west project
       run: |
         rm -rf .west
         west --version
-        west init -l zigbee --mf west.yml &&
-        west update -n -o=--depth=1 --path-cache /workdir/
+        west init -l zigbee --mf west.yml
+        west update -n -o=--depth=1 --path-cache "${WEST_PATH_CACHE}"
+
     - name: Install Python deps for Matter (codegen + factory data)
       run: |
         pip3 install -r nrf/scripts/requirements-extra.txt
         pip3 install -r modules/lib/matter/scripts/setup/requirements.nrfconnect.txt
+
+    - name: Set up ccache
+      run: |
+        mkdir -p "${CCACHE_DIR}"
+        ccache -z
+        ccache -s
+
     - name: Twister build samples
+      # --integration limits each scenario to integration_platforms.
+      # Scenarios tagged no_integration are excluded from PR CI (see sample.yaml).
+      # Quarantine trims platform×scenario pairs for time; keep both layers.
       run: |
         source zephyr/zephyr-env.sh
-        zephyr/scripts/twister --inline-logs --build-only -N --verbose -T zigbee/samples --all -x CONFIG_ZBOSS_HALT_ON_ASSERT=y -x CONFIG_RESET_ON_FATAL_ERROR=n -x CONFIG_FACTORY_RESET_PRESS_TIME_SECONDS=2
+        zephyr/scripts/twister --build-only -N --inline-logs --verbose \
+          -T zigbee/samples \
+          --integration \
+          -e no_integration \
+          --subset ${{ matrix.subset }}/${{ strategy.job-total }} \
+          -j "$(nproc)" \
+          -M pass \
+          -x CONFIG_ZBOSS_HALT_ON_ASSERT=y \
+          -x CONFIG_RESET_ON_FATAL_ERROR=n \
+          -x CONFIG_FACTORY_RESET_PRESS_TIME_SECONDS=2
+
     - name: Store hex files
       uses: actions/upload-artifact@c7d193f32edcb7bfad88892161225aeda64e9392 # v4
       with:
-        name: hexes
+        name: hexes-${{ matrix.subset }}
         path: twister-out/**/*.hex
+        if-no-files-found: ignore

--- a/samples/light_bulb/sample.yaml
+++ b/samples/light_bulb/sample.yaml
@@ -1,6 +1,12 @@
 sample:
   description: Zigbee Light control - light bulb sample
   name: Zigbee Light control
+common:
+  tags:
+    - ci_build
+    - smoke
+    - sysbuild
+    - ci_samples_zigbee
 tests:
   sample.zigbee.light_bulb.matter:
     sysbuild: true
@@ -10,17 +16,11 @@ tests:
       - SNIPPET=matter_fota_ext_flash
     integration_platforms:
       - nrf54l15dk/nrf54l15/cpuapp
-      - nrf54lm20dk/nrf54lm20a/cpuapp
       - nrf54lm20dk/nrf54lm20b/cpuapp
     platform_allow:
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54lm20dk/nrf54lm20a/cpuapp
       - nrf54lm20dk/nrf54lm20b/cpuapp
-    tags:
-      - ci_build
-      - smoke
-      - sysbuild
-      - ci_samples_zigbee
   sample.zigbee.light_bulb.matter.int_flash:
     sysbuild: true
     build_only: true
@@ -29,12 +29,8 @@ tests:
     integration_platforms:
       - nrf54lm20dk/nrf54lm20b/cpuapp
     platform_allow:
+      - nrf54lm20dk/nrf54lm20a/cpuapp
       - nrf54lm20dk/nrf54lm20b/cpuapp
-    tags:
-      - ci_build
-      - smoke
-      - sysbuild
-      - ci_samples_zigbee
   sample.zigbee.light_bulb.matter.release:
     sysbuild: true
     build_only: true
@@ -42,28 +38,19 @@ tests:
       - FILE_SUFFIX=matter_fota
       - SNIPPET=matter_fota_ext_flash
       - EXTRA_CONF_FILE=matter_fota_release.conf
-    integration_platforms:
-      - nrf54l15dk/nrf54l15/cpuapp
-      - nrf54lm20dk/nrf54lm20a/cpuapp
-      - nrf54lm20dk/nrf54lm20b/cpuapp
     platform_allow:
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54lm20dk/nrf54lm20a/cpuapp
       - nrf54lm20dk/nrf54lm20b/cpuapp
     tags:
-      - ci_build
-      - smoke
-      - sysbuild
-      - ci_samples_zigbee
+      - no_integration
   sample.zigbee.light_bulb:
     sysbuild: true
     build_only: true
     integration_platforms:
       - nrf52840dk/nrf52840
       - nrf5340dk/nrf5340/cpuapp
-      - nrf54l15dk/nrf54l10/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
-      - nrf54lm20dk/nrf54lm20a/cpuapp
       - nrf54lm20dk/nrf54lm20b/cpuapp
     platform_allow:
       - nrf52840dk/nrf52840
@@ -72,11 +59,6 @@ tests:
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54lm20dk/nrf54lm20a/cpuapp
       - nrf54lm20dk/nrf54lm20b/cpuapp
-    tags:
-      - ci_build
-      - smoke
-      - sysbuild
-      - ci_samples_zigbee
   sample.zigbee.light_bulb.with_shell:
     sysbuild: true
     build_only: true
@@ -86,13 +68,6 @@ tests:
       - CONFIG_ZIGBEE_LOGGER_EP=n
       - CONFIG_ZIGBEE_SHELL_ENDPOINT=10
       - CONFIG_LOG_MODE_DEFERRED=y
-    integration_platforms:
-      - nrf52840dk/nrf52840
-      - nrf5340dk/nrf5340/cpuapp
-      - nrf54l15dk/nrf54l10/cpuapp
-      - nrf54l15dk/nrf54l15/cpuapp
-      - nrf54lm20dk/nrf54lm20a/cpuapp
-      - nrf54lm20dk/nrf54lm20b/cpuapp
     platform_allow:
       - nrf52840dk/nrf52840
       - nrf5340dk/nrf5340/cpuapp
@@ -101,7 +76,5 @@ tests:
       - nrf54lm20dk/nrf54lm20a/cpuapp
       - nrf54lm20dk/nrf54lm20b/cpuapp
     tags:
-      - ci_build
+      - no_integration
       - shell
-      - sysbuild
-      - ci_samples_zigbee

--- a/samples/light_switch/sample.yaml
+++ b/samples/light_switch/sample.yaml
@@ -1,6 +1,12 @@
 sample:
   description: Zigbee dimmable light switch based on ZBOSS stack
   name: Zigbee Light switch
+common:
+  tags:
+    - ci_build
+    - smoke
+    - sysbuild
+    - ci_samples_zigbee
 tests:
   sample.zigbee.light_switch.matter:
     sysbuild: true
@@ -10,17 +16,11 @@ tests:
       - SNIPPET=matter_fota_ext_flash
     integration_platforms:
       - nrf54l15dk/nrf54l15/cpuapp
-      - nrf54lm20dk/nrf54lm20a/cpuapp
       - nrf54lm20dk/nrf54lm20b/cpuapp
     platform_allow:
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54lm20dk/nrf54lm20a/cpuapp
       - nrf54lm20dk/nrf54lm20b/cpuapp
-    tags:
-      - ci_build
-      - smoke
-      - sysbuild
-      - ci_samples_zigbee
   sample.zigbee.light_switch.matter.int_flash:
     sysbuild: true
     build_only: true
@@ -29,12 +29,8 @@ tests:
     integration_platforms:
       - nrf54lm20dk/nrf54lm20b/cpuapp
     platform_allow:
+      - nrf54lm20dk/nrf54lm20a/cpuapp
       - nrf54lm20dk/nrf54lm20b/cpuapp
-    tags:
-      - ci_build
-      - smoke
-      - sysbuild
-      - ci_samples_zigbee
   sample.zigbee.light_switch.matter.release:
     sysbuild: true
     build_only: true
@@ -42,19 +38,12 @@ tests:
       - FILE_SUFFIX=matter_fota
       - SNIPPET=matter_fota_ext_flash
       - EXTRA_CONF_FILE=matter_fota_release.conf
-    integration_platforms:
-      - nrf54l15dk/nrf54l15/cpuapp
-      - nrf54lm20dk/nrf54lm20a/cpuapp
-      - nrf54lm20dk/nrf54lm20b/cpuapp
     platform_allow:
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54lm20dk/nrf54lm20a/cpuapp
       - nrf54lm20dk/nrf54lm20b/cpuapp
     tags:
-      - ci_build
-      - smoke
-      - sysbuild
-      - ci_samples_zigbee
+      - no_integration
   sample.zigbee.light_switch.matter.bt_dfu:
     sysbuild: true
     build_only: true
@@ -62,25 +51,16 @@ tests:
       - FILE_SUFFIX=matter_fota
       - CONFIG_CHIP_DFU_OVER_BT_SMP=y
     integration_platforms:
-      - nrf54lm20dk/nrf54lm20a/cpuapp
       - nrf54lm20dk/nrf54lm20b/cpuapp
     platform_allow:
       - nrf54lm20dk/nrf54lm20a/cpuapp
       - nrf54lm20dk/nrf54lm20b/cpuapp
-    tags:
-      - ci_build
-      - smoke
-      - sysbuild
-      - ci_samples_zigbee
   sample.zigbee.light_switch:
     sysbuild: true
     build_only: true
     integration_platforms:
       - nrf52840dk/nrf52840
-      - nrf5340dk/nrf5340/cpuapp
-      - nrf54l15dk/nrf54l10/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
-      - nrf54lm20dk/nrf54lm20a/cpuapp
       - nrf54lm20dk/nrf54lm20b/cpuapp
     platform_allow:
       - nrf52840dk/nrf52840
@@ -89,21 +69,13 @@ tests:
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54lm20dk/nrf54lm20a/cpuapp
       - nrf54lm20dk/nrf54lm20b/cpuapp
-    tags:
-      - ci_build
-      - smoke
-      - sysbuild
-      - ci_samples_zigbee
   sample.zigbee.light_switch.multiprotocol:
     sysbuild: true
     build_only: true
     extra_args: OVERLAY_CONFIG=overlay-multiprotocol_ble.conf
     integration_platforms:
-      - nrf52840dk/nrf52840
       - nrf5340dk/nrf5340/cpuapp
-      - nrf54l15dk/nrf54l10/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
-      - nrf54lm20dk/nrf54lm20a/cpuapp
       - nrf54lm20dk/nrf54lm20b/cpuapp
     platform_allow:
       - nrf52840dk/nrf52840
@@ -112,10 +84,6 @@ tests:
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54lm20dk/nrf54lm20a/cpuapp
       - nrf54lm20dk/nrf54lm20b/cpuapp
-    tags:
-      - ci_build
-      - sysbuild
-      - ci_samples_zigbee
   sample.zigbee.light_switch.with_shell:
     sysbuild: true
     build_only: true
@@ -125,13 +93,6 @@ tests:
       - CONFIG_ZIGBEE_LOGGER_EP=n
       - CONFIG_ZIGBEE_SHELL_ENDPOINT=1
       - CONFIG_LOG_MODE_DEFERRED=y
-    integration_platforms:
-      - nrf52840dk/nrf52840
-      - nrf5340dk/nrf5340/cpuapp
-      - nrf54l15dk/nrf54l10/cpuapp
-      - nrf54l15dk/nrf54l15/cpuapp
-      - nrf54lm20dk/nrf54lm20a/cpuapp
-      - nrf54lm20dk/nrf54lm20b/cpuapp
     platform_allow:
       - nrf52840dk/nrf52840
       - nrf5340dk/nrf5340/cpuapp
@@ -140,10 +101,7 @@ tests:
       - nrf54lm20dk/nrf54lm20a/cpuapp
       - nrf54lm20dk/nrf54lm20b/cpuapp
     tags:
-      - ci_build
-      - shell
-      - sysbuild
-      - ci_samples_zigbee
+      - no_integration
   sample.zigbee.light_switch.fota:
     sysbuild: true
     build_only: true
@@ -151,10 +109,7 @@ tests:
       - FILE_SUFFIX=fota
     integration_platforms:
       - nrf52840dk/nrf52840
-      - nrf5340dk/nrf5340/cpuapp
-      - nrf54l15dk/nrf54l10/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
-      - nrf54lm20dk/nrf54lm20a/cpuapp
       - nrf54lm20dk/nrf54lm20b/cpuapp
     platform_allow:
       - nrf52840dk/nrf52840
@@ -163,11 +118,6 @@ tests:
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54lm20dk/nrf54lm20a/cpuapp
       - nrf54lm20dk/nrf54lm20b/cpuapp
-    tags:
-      - ci_build
-      - smoke
-      - sysbuild
-      - ci_samples_zigbee
   sample.zigbee.light_switch.fota_and_multiprotocol:
     sysbuild: true
     build_only: true
@@ -177,18 +127,12 @@ tests:
     integration_platforms:
       - nrf5340dk/nrf5340/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
-      - nrf54lm20dk/nrf54lm20a/cpuapp
       - nrf54lm20dk/nrf54lm20b/cpuapp
     platform_allow:
       - nrf5340dk/nrf5340/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54lm20dk/nrf54lm20a/cpuapp
       - nrf54lm20dk/nrf54lm20b/cpuapp
-    tags:
-      - ci_build
-      - smoke
-      - sysbuild
-      - ci_samples_zigbee
   sample.zigbee.light_switch.fota_and_bt_dfu:
     sysbuild: true
     build_only: true
@@ -200,7 +144,6 @@ tests:
       - nrf5340dk/nrf5340/cpuapp
       - nrf54l15dk/nrf54l10/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
-      - nrf54lm20dk/nrf54lm20a/cpuapp
       - nrf54lm20dk/nrf54lm20b/cpuapp
     platform_allow:
       - nrf52840dk/nrf52840
@@ -209,11 +152,6 @@ tests:
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54lm20dk/nrf54lm20a/cpuapp
       - nrf54lm20dk/nrf54lm20b/cpuapp
-    tags:
-      - ci_build
-      - smoke
-      - sysbuild
-      - ci_samples_zigbee
   sample.zigbee.light_switch.low_power:
     sysbuild: true
     build_only: true
@@ -222,9 +160,7 @@ tests:
     integration_platforms:
       - nrf52840dk/nrf52840
       - nrf5340dk/nrf5340/cpuapp
-      - nrf54l15dk/nrf54l10/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
-      - nrf54lm20dk/nrf54lm20a/cpuapp
       - nrf54lm20dk/nrf54lm20b/cpuapp
     platform_allow:
       - nrf52840dk/nrf52840
@@ -233,8 +169,3 @@ tests:
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54lm20dk/nrf54lm20a/cpuapp
       - nrf54lm20dk/nrf54lm20b/cpuapp
-    tags:
-      - ci_build
-      - smoke
-      - sysbuild
-      - ci_samples_zigbee

--- a/samples/ncp/sample.yaml
+++ b/samples/ncp/sample.yaml
@@ -1,6 +1,12 @@
 sample:
   description: Zigbee network co-processor
   name: Zigbee NCP
+common:
+  tags:
+    - ci_build
+    - smoke
+    - sysbuild
+    - ci_samples_zigbee
 tests:
   sample.zigbee.ncp:
     sysbuild: true
@@ -8,12 +14,7 @@ tests:
     integration_platforms:
       - nrf52833dk/nrf52833
       - nrf52840dk/nrf52840
-      - nrf5340dk/nrf5340/cpuapp
       - nrf54l15dk/nrf54l05/cpuapp
-      - nrf54l15dk/nrf54l10/cpuapp
-      - nrf54l15dk/nrf54l15/cpuapp
-      - nrf54lm20dk/nrf54lm20a/cpuapp
-      - nrf54lm20dk/nrf54lm20b/cpuapp
     platform_allow:
       - nrf52833dk/nrf52833
       - nrf52840dk/nrf52840
@@ -23,31 +24,18 @@ tests:
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54lm20dk/nrf54lm20a/cpuapp
       - nrf54lm20dk/nrf54lm20b/cpuapp
-    tags:
-      - ci_build
-      - smoke
-      - sysbuild
-      - ci_samples_zigbee
   sample.zigbee.ncp.usb:
     sysbuild: true
     build_only: true
     integration_platforms:
       - nrf52833dk/nrf52833
       - nrf52840dk/nrf52840
-      - nrf5340dk/nrf5340/cpuapp
-      - nrf54lm20dk/nrf54lm20a/cpuapp
-      - nrf54lm20dk/nrf54lm20b/cpuapp
     platform_allow:
       - nrf52833dk/nrf52833
       - nrf52840dk/nrf52840
       - nrf5340dk/nrf5340/cpuapp
       - nrf54lm20dk/nrf54lm20a/cpuapp
       - nrf54lm20dk/nrf54lm20b/cpuapp
-    tags:
-      - ci_build
-      - ncp
-      - sysbuild
-      - ci_samples_zigbee
     extra_args:
       - FILE_SUFFIX=usb
   sample.zigbee.ncp.dongle:
@@ -57,10 +45,5 @@ tests:
       - nrf52840dongle/nrf52840
     platform_allow:
       - nrf52840dongle/nrf52840
-    tags:
-      - ci_build
-      - ncp
-      - sysbuild
-      - ci_samples_zigbee
     extra_args:
       - FILE_SUFFIX=dongle

--- a/samples/network_coordinator/sample.yaml
+++ b/samples/network_coordinator/sample.yaml
@@ -1,16 +1,19 @@
 sample:
   description: Zigbee Light control - coordinator sample
   name: Zigbee Network coordinator
+common:
+  tags:
+    - ci_build
+    - smoke
+    - sysbuild
+    - ci_samples_zigbee
 tests:
   sample.zigbee.network_coordinator:
     sysbuild: true
     build_only: true
     integration_platforms:
-      - nrf52840dk/nrf52840
       - nrf5340dk/nrf5340/cpuapp
-      - nrf54l15dk/nrf54l10/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
-      - nrf54lm20dk/nrf54lm20a/cpuapp
       - nrf54lm20dk/nrf54lm20b/cpuapp
     platform_allow:
       - nrf52840dk/nrf52840
@@ -19,8 +22,3 @@ tests:
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54lm20dk/nrf54lm20a/cpuapp
       - nrf54lm20dk/nrf54lm20b/cpuapp
-    tags:
-      - ci_build
-      - smoke
-      - sysbuild
-      - ci_samples_zigbee

--- a/samples/shell/sample.yaml
+++ b/samples/shell/sample.yaml
@@ -1,6 +1,12 @@
 sample:
   description: Zigbee application that includes all Zigbee shell commands
   name: Zigbee application with Zigbee shell
+common:
+  tags:
+    - sysbuild
+    - ci_build
+    - shell
+    - ci_samples_zigbee
 tests:
   sample.zigbee.shell:
     build_only: true
@@ -8,9 +14,7 @@ tests:
     integration_platforms:
       - nrf52840dk/nrf52840
       - nrf5340dk/nrf5340/cpuapp
-      - nrf54l15dk/nrf54l10/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
-      - nrf54lm20dk/nrf54lm20a/cpuapp
       - nrf54lm20dk/nrf54lm20b/cpuapp
     platform_allow:
       - nrf52840dk/nrf52840
@@ -19,19 +23,12 @@ tests:
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54lm20dk/nrf54lm20a/cpuapp
       - nrf54lm20dk/nrf54lm20b/cpuapp
-    tags:
-      - ci_build
-      - shell
-      - sysbuild
-      - ci_samples_zigbee
   sample.zigbee.shell.usb:
     sysbuild: true
     build_only: true
     integration_platforms:
-      - nrf52840dk/nrf52840
       - nrf52840dongle/nrf52840
       - nrf5340dk/nrf5340/cpuapp
-      - nrf54lm20dk/nrf54lm20a/cpuapp
       - nrf54lm20dk/nrf54lm20b/cpuapp
     platform_allow:
       - nrf52840dk/nrf52840
@@ -39,10 +36,5 @@ tests:
       - nrf5340dk/nrf5340/cpuapp
       - nrf54lm20dk/nrf54lm20a/cpuapp
       - nrf54lm20dk/nrf54lm20b/cpuapp
-    tags:
-      - ci_build
-      - shell
-      - sysbuild
-      - ci_samples_zigbee
     extra_args:
       - FILE_SUFFIX=usb

--- a/samples/template/sample.yaml
+++ b/samples/template/sample.yaml
@@ -1,17 +1,19 @@
 sample:
   description: Zigbee application template
   name: Zigbee application template
+common:
+  tags:
+    - ci_build
+    - smoke
+    - sysbuild
+    - ci_samples_zigbee
 tests:
   sample.zigbee.template:
     sysbuild: true
     build_only: true
     integration_platforms:
-      - nrf52840dk/nrf52840
-      - nrf5340dk/nrf5340/cpuapp
       - nrf54l15dk/nrf54l10/cpuapp
-      - nrf54l15dk/nrf54l15/cpuapp
       - nrf54lm20dk/nrf54lm20a/cpuapp
-      - nrf54lm20dk/nrf54lm20b/cpuapp
     platform_allow:
       - nrf52840dk/nrf52840
       - nrf5340dk/nrf5340/cpuapp
@@ -19,8 +21,3 @@ tests:
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54lm20dk/nrf54lm20a/cpuapp
       - nrf54lm20dk/nrf54lm20b/cpuapp
-    tags:
-      - ci_build
-      - smoke
-      - sysbuild
-      - ci_samples_zigbee


### PR DESCRIPTION
Speed up PR sample builds with quarantine and parallel twister. Add integration quarantine rules to cut redundant platform coverage and shared CI across four jobs with ccache and west/pip caching.