### PR TITLE
samples: allow Touchlink initiator activation during coexistence

### DIFF
--- a/include/zigbee/matter_coexistence.h
+++ b/include/zigbee/matter_coexistence.h
@@ -86,15 +86,19 @@ void zigbee_matter_coexistence_signal_matter_board_init(void);
  *
  * Detects a long press on @p switch_button and requests a protocol switch
  * when @kconfig{CONFIG_ZIGBEE_MATTER_COEXISTENCE_SWITCH_BUTTON_PRESS_TIME_SECONDS}
- * expires.
+ * expires. A release before that timeout is reported as a short press so the
+ * sample can assign another action to the same button (for example Touchlink).
  *
  * Call this before other sample-specific button checks.
  *
  * @param button_state Current button state bitmask.
  * @param has_changed  Button-change bitmask from DK callback.
  * @param switch_button Bitmask of the switch button (one DK button).
+ *
+ * @retval true  @p switch_button was released before the long-press timeout.
+ * @retval false Any other event (including press start or unrelated buttons).
  */
-void zigbee_matter_coexistence_process_switch_button(uint32_t button_state, uint32_t has_changed,
+bool zigbee_matter_coexistence_process_switch_button(uint32_t button_state, uint32_t has_changed,
 						     uint32_t switch_button);
 
 #ifdef __cplusplus

--- a/samples/light_switch/README.rst
+++ b/samples/light_switch/README.rst
@@ -126,7 +126,8 @@ This lets the device commission directly with a nearby Touchlink target (for exa
 
    .. group-tab:: nRF54 DKs
 
-      Press **Button 2** during normal operation to start Touchlink commissioning.
+      Short-press **Button 2** during normal operation to start Touchlink commissioning.
+      In the Matter extension build, a long press on the same button switches protocol instead; see :ref:`zigbee_light_switch_matter_limitations`.
 
 .. note::
    Touchlink in the |addon| for the |NCS| is provided as an experimental feature with basic functionality.
@@ -334,7 +335,7 @@ Matter extension Touchlink assignments
    .. group-tab:: nRF54 DKs
 
       Button 2:
-          When you are building the sample with the Matter extension and press the button during normal operation (after boot), it starts Touchlink commissioning as initiator.
+          When you are building the sample with the Matter extension, a short press during normal operation (after boot) starts Touchlink commissioning as initiator.
           See :ref:`zigbee_light_switch_sample_touchlink`.
 
 Matter extension protocol switch assignments
@@ -345,7 +346,7 @@ Matter extension protocol switch assignments
    .. group-tab:: nRF54 DKs
 
       Button 2:
-          If ``CONFIG_ZIGBEE_MATTER_COEXISTENCE_BUTTON_SWITCH`` is enabled (default), it triggers a protocol switch after a long press (``CONFIG_ZIGBEE_MATTER_COEXISTENCE_SWITCH_BUTTON_PRESS_TIME_SECONDS``, 5 s by default).
+          If ``CONFIG_ZIGBEE_MATTER_COEXISTENCE_BUTTON_SWITCH`` is enabled (default), a long press (``CONFIG_ZIGBEE_MATTER_COEXISTENCE_SWITCH_BUTTON_PRESS_TIME_SECONDS``, 5 s by default) triggers a protocol switch.
 
 Multiprotocol Bluetooth LE extension assignments
 ================================================

--- a/samples/light_switch/src/app_task_zigbee.c
+++ b/samples/light_switch/src/app_task_zigbee.c
@@ -100,12 +100,12 @@
 #define BUTTON_SLEEPY              DK_BTN3_MSK
 
 #if defined(CONFIG_ZIGBEE_TOUCHLINK_INITIATOR)
-/* Start Touchlink initiator at runtime (same pin as BUTTON_SLEEPY). */
+/* Short press starts Touchlink. */
 #define BUTTON_TOUCHLINK           DK_BTN3_MSK
 #endif
 
 #if defined(CONFIG_ZIGBEE_MATTER_COEXISTENCE_BUTTON_SWITCH)
-/* Long-press to switch active protocol. */
+/* Long press switches protocol in coex builds. */
 #define PROTOCOL_SWITCH_BUTTON     DK_BTN3_MSK
 #endif
 
@@ -294,9 +294,15 @@ static void zb_button_handler_impl(uint32_t button_state, uint32_t has_changed)
 	zb_ret_t zb_err_code;
 
 #ifdef CONFIG_ZIGBEE_MATTER_COEXISTENCE
-#ifdef CONFIG_ZIGBEE_MATTER_COEXISTENCE_BUTTON_SWITCH
+#if defined(CONFIG_ZIGBEE_MATTER_COEXISTENCE_BUTTON_SWITCH)
+#if defined(CONFIG_ZIGBEE_TOUCHLINK_INITIATOR)
+	bool protocol_switch_short_release =
+		zigbee_matter_coexistence_process_switch_button(button_state, has_changed,
+								PROTOCOL_SWITCH_BUTTON);
+#else
 	(void)zigbee_matter_coexistence_process_switch_button(button_state, has_changed,
-							       PROTOCOL_SWITCH_BUTTON);
+							      PROTOCOL_SWITCH_BUTTON);
+#endif
 #endif
 
 	if (!protocol_is_zigbee_active()) {
@@ -309,11 +315,19 @@ static void zb_button_handler_impl(uint32_t button_state, uint32_t has_changed)
 
 	check_factory_reset_button(button_state, has_changed);
 
-#if defined(CONFIG_ZIGBEE_TOUCHLINK_INITIATOR) && !defined(CONFIG_ZIGBEE_MATTER_COEXISTENCE)
+#if defined(CONFIG_ZIGBEE_TOUCHLINK_INITIATOR)
+#if defined(CONFIG_ZIGBEE_MATTER_COEXISTENCE) && \
+	defined(CONFIG_ZIGBEE_MATTER_COEXISTENCE_BUTTON_SWITCH)
+	if (protocol_switch_short_release) {
+		ZB_SCHEDULE_APP_CALLBACK(light_switch_touchlink_initiator_start_cb, 0);
+		return;
+	}
+#else
 	if ((has_changed & BUTTON_TOUCHLINK) && (button_state & BUTTON_TOUCHLINK)) {
 		ZB_SCHEDULE_APP_CALLBACK(light_switch_touchlink_initiator_start_cb, 0);
 		return;
 	}
+#endif
 #endif
 
 	if (bulb_ctx.short_addr == 0xFFFF) {

--- a/subsys/lib/zigbee_matter_coexistence/coexistence.cpp
+++ b/subsys/lib/zigbee_matter_coexistence/coexistence.cpp
@@ -216,12 +216,12 @@ extern "C" int zigbee_matter_coexistence_run(const struct zigbee_matter_coexiste
 	return 0;
 }
 
-extern "C" void zigbee_matter_coexistence_process_switch_button(uint32_t button_state,
+extern "C" bool zigbee_matter_coexistence_process_switch_button(uint32_t button_state,
 								uint32_t has_changed,
 								uint32_t switch_button)
 {
 	if (switch_button == 0U) {
-		return;
+		return false;
 	}
 
 	const bool pressed = (has_changed & switch_button) && (button_state & switch_button);
@@ -233,9 +233,15 @@ extern "C" void zigbee_matter_coexistence_process_switch_button(uint32_t button_
 		LOG_INF("Protocol switch press started (mask 0x%08x)", switch_button);
 		k_work_reschedule(&protocol_switch_work,
 				  K_SECONDS(CONFIG_ZIGBEE_MATTER_COEXISTENCE_SWITCH_BUTTON_PRESS_TIME_SECONDS));
-	} else if (press_active && released) {
+		return false;
+	}
+
+	if (press_active && released) {
 		LOG_INF("Protocol switch press canceled before timeout");
 		atomic_set(&g_switch_press_active, 0);
 		(void)k_work_cancel_delayable(&protocol_switch_work);
+		return true;
 	}
+
+	return false;
 }


### PR DESCRIPTION
Previously the BUTTON_TOUCHLINK was only check for Zigbee only builds.