### PR TITLE
coexistence: fix protocol switch back to Zigbee

### DIFF
--- a/docs/includes/matter_extension_protocol_switch.txt
+++ b/docs/includes/matter_extension_protocol_switch.txt
@@ -9,8 +9,34 @@ From Zigbee, the coexistence layer stops the ZBOSS stack and hands the 802.15.4 
 From Matter, the device persists Zigbee as the active protocol and reboots.
 The protocol switch is ignored while the device is joining a Zigbee network or undergoing Matter commissioning.
 
+Integrating the coexistence layer in ``AppTask::Init()`` requires two call sites:
+
+1. Pass ``zigbee_matter_coexistence_pre_server_init`` as ``mPreServerInitClbk`` in ``Nrf::Matter::InitData`` before calling ``Nrf::Matter::PrepareServer()``.
+   This temporarily transfers the 802.15.4 radio to OpenThread so that ``InitThreadStack()`` can initialize the OT radio platform safely while Zigbee owns the dispatcher.
+
+2. Call ``zigbee_matter_coexistence_on_server_started()`` immediately after ``Nrf::Matter::StartServer()`` succeeds.
+   This restores the 802.15.4 dispatcher to Zigbee, disables the OT IP6 interface so OpenThread does not access the radio while inactive, and unblocks the Zigbee worker thread.
+
+The following example shows the required structure:
+
+.. code-block:: cpp
+
+   Nrf::Matter::InitData initData{};
+   initData.mPostServerInitClbk = []() -> CHIP_ERROR {
+       /* sample-specific init */
+       return CHIP_NO_ERROR;
+   };
+   initData.mPreServerInitClbk  = []() -> CHIP_ERROR {
+       zigbee_matter_coexistence_pre_server_init();
+       return CHIP_NO_ERROR;
+   };
+   ReturnErrorOnFailure(Nrf::Matter::PrepareServer(initData));
+   // ...
+   ReturnErrorOnFailure(Nrf::Matter::StartServer());
+   zigbee_matter_coexistence_on_server_started();
+
 Other Kconfig options in the coexistence layer:
 
 * ``CONFIG_ZIGBEE_MATTER_COEXISTENCE_BT_ADV_WHILE_ZIGBEE`` (default enabled) — Matter may advertise for commissioning over Bluetooth LE while Zigbee owns the 802.15.4 radio.
-  When disabled, the sample must call ``zigbee_matter_coexistence_signal_matter_board_init()`` after Matter server init, and the Zigbee worker proceeds without waiting for CHIPoBLE advertising.
+  When disabled, the Zigbee worker is unblocked directly from ``zigbee_matter_coexistence_on_server_started()`` without waiting for CHIPoBLE advertising.
 * ``CONFIG_ZIGBEE_MATTER_COEXISTENCE_BUTTON_SWITCH`` — Enable or disable the button-triggered protocol switch.

--- a/include/zigbee/matter_coexistence.h
+++ b/include/zigbee/matter_coexistence.h
@@ -30,6 +30,8 @@
 extern "C" {
 #endif
 
+#include <zboss_api.h>
+
 /** @brief Callbacks supplied by the sample. */
 struct zigbee_matter_coexistence_callbacks {
 	/** Start the Matter application. Invoked from the Matter worker
@@ -121,16 +123,20 @@ bool zigbee_matter_coexistence_process_switch_button(uint32_t button_state, uint
 						     uint32_t switch_button);
 
 
-/** @brief Notify the coexistence runtime that the local ZDO/NWK leave has completed.
+/** @brief Forward selected ZBOSS application signals to the coexistence runtime.
  *
- * Must be called from the application's @c zboss_signal_handler when a
- * @c ZB_ZDO_SIGNAL_LEAVE event with leave_type @c ZB_NWK_LEAVE_TYPE_RESET
- * is received.  If a Matter protocol switch was deferred pending the leave,
- * this call unblocks it so the radio hand-over to OpenThread can proceed.
+ * Call from the application's @c zboss_signal_handler before
+ * @ref zigbee_default_signal_handler.  When @p bufid carries a successful
+ * @c ZB_ZDO_SIGNAL_LEAVE with leave_type @c ZB_NWK_LEAVE_TYPE_RESET, a
+ * pending Matter protocol switch is unblocked so the radio hand-over to
+ * OpenThread can proceed.
  *
- * Safe to call unconditionally; it is a no-op when no switch is pending.
+ * Safe to call unconditionally for any signal buffer; it is a no-op for
+ * unrelated signals and when no switch is pending.
+ *
+ * @param bufid ZBOSS application signal buffer, or @c 0 if invalid.
  */
-void zigbee_matter_coexistence_on_zboss_leave_signal(void);
+void zigbee_matter_coexistence_handle_zboss_signal(zb_bufid_t bufid);
 
 #ifdef __cplusplus
 }

--- a/include/zigbee/matter_coexistence.h
+++ b/include/zigbee/matter_coexistence.h
@@ -46,8 +46,8 @@ struct zigbee_matter_coexistence_callbacks {
 	/** Hook run on the Zigbee worker thread once Matter is ready for the
 	 *  Zigbee phase (CHIPoBLE advertising started when
 	 *  @kconfig{CONFIG_ZIGBEE_MATTER_COEXISTENCE_BT_ADV_WHILE_ZIGBEE},
-	 *  otherwise after the sample calls
-	 *  @ref zigbee_matter_coexistence_signal_matter_board_init).
+	 *  otherwise after @ref zigbee_matter_coexistence_on_server_started
+	 *  unblocks the Zigbee worker).
 	 *  Typically used to register a chained Zigbee button handler with
 	 *  the DK buttons library after @c dk_buttons_init() has completed.
 	 *  May be NULL.
@@ -72,15 +72,34 @@ struct zigbee_matter_coexistence_callbacks {
  */
 int zigbee_matter_coexistence_run(const struct zigbee_matter_coexistence_callbacks *cb);
 
-/** @brief Notify the coexistence runtime that Matter board init is complete.
+/** @brief Notify the coexistence runtime that @c Nrf::Matter::StartServer() has returned.
  *
- * Call from the Matter worker thread after @c Nrf::Matter::StartServer()
- * returns successfully when
- * @kconfig{CONFIG_ZIGBEE_MATTER_COEXISTENCE_BT_ADV_WHILE_ZIGBEE} is
- * disabled. Unblocks the Zigbee worker so it can chain button handlers and
- * start the Zigbee stack.
+ * Call unconditionally from the Matter worker thread's @c AppTask::Init()
+ * immediately after @c Nrf::Matter::StartServer() succeeds.  Internally
+ * handles all coexistence signaling variants:
+ *
+ * - When @kconfig{CONFIG_ZIGBEE_MATTER_COEXISTENCE_BT_ADV_WHILE_ZIGBEE} is
+ *   disabled: unblocks the Zigbee worker unconditionally.
+ * - When it is enabled: unblocks the Zigbee worker only on a Zigbee boot
+ *   that follows a prior Matter commissioning (i.e. the device already has
+ *   a fabric), because BLE advertising will not restart and the normal
+ *   @c kCHIPoBLEAdvertisingChange signal will never fire.
  */
-void zigbee_matter_coexistence_signal_matter_board_init(void);
+void zigbee_matter_coexistence_on_server_started(void);
+
+/**
+ * @brief Prepare 802.15.4 radio for safe Matter server initialization.
+ *
+ * Call this as @c mPreServerInitClbk in @c Nrf::Matter::InitData before
+ * calling @c Nrf::Matter::PrepareServer().  When the device boots in Zigbee
+ * mode, temporarily switches the 802.15.4 callbacks dispatcher to OpenThread
+ * so that @c InitThreadStack() can initialise the OT radio platform without
+ * crashing.  @ref zigbee_matter_coexistence_on_server_started restores the
+ * dispatcher to Zigbee once @c StartServer() returns.
+ *
+ * This function is a no-op when the device boots in Matter mode.
+ */
+void zigbee_matter_coexistence_pre_server_init(void);
 
 /** @brief Process button events for user-triggered protocol switching.
  *
@@ -100,6 +119,18 @@ void zigbee_matter_coexistence_signal_matter_board_init(void);
  */
 bool zigbee_matter_coexistence_process_switch_button(uint32_t button_state, uint32_t has_changed,
 						     uint32_t switch_button);
+
+
+/** @brief Notify the coexistence runtime that the local ZDO/NWK leave has completed.
+ *
+ * Must be called from the application's @c zboss_signal_handler when a
+ * @c ZB_ZDO_SIGNAL_LEAVE event with leave_type @c ZB_NWK_LEAVE_TYPE_RESET
+ * is received.  If a Matter protocol switch was deferred pending the leave,
+ * this call unblocks it so the radio hand-over to OpenThread can proceed.
+ *
+ * Safe to call unconditionally; it is a no-op when no switch is pending.
+ */
+void zigbee_matter_coexistence_on_zboss_leave_signal(void);
 
 #ifdef __cplusplus
 }

--- a/samples/light_bulb/src/app_task_matter.cpp
+++ b/samples/light_bulb/src/app_task_matter.cpp
@@ -22,8 +22,7 @@
 #include <app/server/Server.h>
 #include <setup_payload/OnboardingCodesUtil.h>
 
-#if defined(CONFIG_ZIGBEE_MATTER_COEXISTENCE) && \
-	!defined(CONFIG_ZIGBEE_MATTER_COEXISTENCE_BT_ADV_WHILE_ZIGBEE)
+#if defined(CONFIG_ZIGBEE_MATTER_COEXISTENCE)
 #include <zigbee/matter_coexistence.h>
 #endif
 
@@ -198,13 +197,20 @@ void AppTask::InitPWMDDevice() {
 
 CHIP_ERROR AppTask::Init() {
   /* Initialize Matter stack */
-  ReturnErrorOnFailure(Nrf::Matter::PrepareServer(
-      Nrf::Matter::InitData{.mPostServerInitClbk = []() {
-        app::SetAttributePersistenceProvider(&gDeferredAttributePersister);
-        gSimpleAttributePersistence.Init(
-            Nrf::Matter::GetPersistentStorageDelegate());
-        return CHIP_NO_ERROR;
-      }}));
+  Nrf::Matter::InitData initData{};
+  initData.mPostServerInitClbk = []() {
+    app::SetAttributePersistenceProvider(&gDeferredAttributePersister);
+    gSimpleAttributePersistence.Init(
+        Nrf::Matter::GetPersistentStorageDelegate());
+    return CHIP_NO_ERROR;
+  };
+#if defined(CONFIG_ZIGBEE_MATTER_COEXISTENCE)
+  initData.mPreServerInitClbk = []() -> CHIP_ERROR {
+    zigbee_matter_coexistence_pre_server_init();
+    return CHIP_NO_ERROR;
+  };
+#endif
+  ReturnErrorOnFailure(Nrf::Matter::PrepareServer(initData));
 
   if (!Nrf::GetBoard().Init(ButtonEventHandler)) {
     LOG_ERR("User interface initialization failed.");
@@ -220,9 +226,8 @@ CHIP_ERROR AppTask::Init() {
 
   ReturnErrorOnFailure(Nrf::Matter::StartServer());
 
-#if defined(CONFIG_ZIGBEE_MATTER_COEXISTENCE) && \
-	!defined(CONFIG_ZIGBEE_MATTER_COEXISTENCE_BT_ADV_WHILE_ZIGBEE)
-  zigbee_matter_coexistence_signal_matter_board_init();
+#if defined(CONFIG_ZIGBEE_MATTER_COEXISTENCE)
+  zigbee_matter_coexistence_on_server_started();
 #endif
 
   return CHIP_NO_ERROR;

--- a/samples/light_bulb/src/app_task_zigbee.cpp
+++ b/samples/light_bulb/src/app_task_zigbee.cpp
@@ -592,6 +592,10 @@ void zboss_signal_handler(zb_bufid_t bufid) {
   zigbee_touchlink_target_signal_handler(bufid);
 #endif
 
+#ifdef CONFIG_ZIGBEE_MATTER_COEXISTENCE
+  zigbee_matter_coexistence_handle_zboss_signal(bufid);
+#endif
+
   ZB_ERROR_CHECK(zigbee_default_signal_handler(bufid));
 
   /* All callbacks should either reuse or free passed buffers.

--- a/samples/light_switch/src/app_task_matter.cpp
+++ b/samples/light_switch/src/app_task_matter.cpp
@@ -15,8 +15,7 @@
 
 #include <setup_payload/OnboardingCodesUtil.h>
 
-#if defined(CONFIG_ZIGBEE_MATTER_COEXISTENCE) && \
-	!defined(CONFIG_ZIGBEE_MATTER_COEXISTENCE_BT_ADV_WHILE_ZIGBEE)
+#if defined(CONFIG_ZIGBEE_MATTER_COEXISTENCE)
 #include <zigbee/matter_coexistence.h>
 #endif
 
@@ -142,10 +141,18 @@ void AppTask::UserTimerTimeoutCallback(k_timer *timer)
 CHIP_ERROR AppTask::Init()
 {
 	/* Initialize Matter stack */
-	ReturnErrorOnFailure(Nrf::Matter::PrepareServer(Nrf::Matter::InitData{ .mPostServerInitClbk = [] {
+	Nrf::Matter::InitData initData{};
+	initData.mPostServerInitClbk = [] {
 		LightSwitch::GetInstance().Init(kLightSwitchEndpointId);
 		return CHIP_NO_ERROR;
-	} }));
+	};
+#if defined(CONFIG_ZIGBEE_MATTER_COEXISTENCE)
+	initData.mPreServerInitClbk = []() -> CHIP_ERROR {
+		zigbee_matter_coexistence_pre_server_init();
+		return CHIP_NO_ERROR;
+	};
+#endif
+	ReturnErrorOnFailure(Nrf::Matter::PrepareServer(initData));
 
 	/* Initialize application timers */
 	k_timer_init(&sDimmerPressKeyTimer, AppTask::UserTimerTimeoutCallback, nullptr);
@@ -164,9 +171,8 @@ CHIP_ERROR AppTask::Init()
 
 	ReturnErrorOnFailure(Nrf::Matter::StartServer());
 
-#if defined(CONFIG_ZIGBEE_MATTER_COEXISTENCE) && \
-	!defined(CONFIG_ZIGBEE_MATTER_COEXISTENCE_BT_ADV_WHILE_ZIGBEE)
-	zigbee_matter_coexistence_signal_matter_board_init();
+#if defined(CONFIG_ZIGBEE_MATTER_COEXISTENCE)
+	zigbee_matter_coexistence_on_server_started();
 #endif
 
 	return CHIP_NO_ERROR;

--- a/samples/light_switch/src/app_task_zigbee.c
+++ b/samples/light_switch/src/app_task_zigbee.c
@@ -779,6 +779,11 @@ void zboss_signal_handler(zb_bufid_t bufid)
 
 			if (leave_params->leave_type == ZB_NWK_LEAVE_TYPE_RESET) {
 				bulb_ctx.short_addr = 0xFFFF;
+#ifdef CONFIG_ZIGBEE_MATTER_COEXISTENCE
+				/* Unblock a pending Matter switch that was deferred
+				 * until the coordinator had been notified via Leave. */
+				zigbee_matter_coexistence_on_zboss_leave_signal();
+#endif
 			}
 		}
 		/* Call default signal handler. */

--- a/samples/light_switch/src/app_task_zigbee.c
+++ b/samples/light_switch/src/app_task_zigbee.c
@@ -740,6 +740,10 @@ void zboss_signal_handler(zb_bufid_t bufid)
 	zigbee_fota_signal_handler(bufid);
 #endif /* CONFIG_ZIGBEE_FOTA */
 
+#ifdef CONFIG_ZIGBEE_MATTER_COEXISTENCE
+	zigbee_matter_coexistence_handle_zboss_signal(bufid);
+#endif
+
 	switch (sig) {
 #if defined(CONFIG_ZIGBEE_TOUCHLINK_INITIATOR)
 	case ZB_BDB_SIGNAL_TOUCHLINK:
@@ -779,11 +783,6 @@ void zboss_signal_handler(zb_bufid_t bufid)
 
 			if (leave_params->leave_type == ZB_NWK_LEAVE_TYPE_RESET) {
 				bulb_ctx.short_addr = 0xFFFF;
-#ifdef CONFIG_ZIGBEE_MATTER_COEXISTENCE
-				/* Unblock a pending Matter switch that was deferred
-				 * until the coordinator had been notified via Leave. */
-				zigbee_matter_coexistence_on_zboss_leave_signal();
-#endif
 			}
 		}
 		/* Call default signal handler. */

--- a/subsys/lib/zigbee_matter_coexistence/CMakeLists.txt
+++ b/subsys/lib/zigbee_matter_coexistence/CMakeLists.txt
@@ -36,3 +36,9 @@ zephyr_library_compile_options($<$<COMPILE_LANGUAGE:CXX>:-std=gnu++17>)
 # Matter public headers use deprecated symbols in some CHIP releases; the
 # sample's own target_compile_options does not propagate here.
 zephyr_library_compile_options(-Wno-deprecated-declarations)
+
+# While Zigbee owns the 802.15.4 radio, OpenThread must not auto-start even
+# when a Thread dataset is already provisioned.  The coexistence runtime
+# starts Thread explicitly after switching the callbacks dispatcher to
+# OpenThread.
+zephyr_compile_definitions(CHIP_DEVICE_CONFIG_ENABLE_THREAD_AUTOSTART=0)

--- a/subsys/lib/zigbee_matter_coexistence/Kconfig
+++ b/subsys/lib/zigbee_matter_coexistence/Kconfig
@@ -35,12 +35,11 @@ config ZIGBEE_MATTER_COEXISTENCE_BT_ADV_WHILE_ZIGBEE
 
 	  Requires CONFIG_CHIP_ENABLE_PAIRING_AUTOSTART in the application.
 
-	  When disabled, the sample must call
-	  zigbee_matter_coexistence_signal_matter_board_init() after Matter
-	  server init completes.
-	  The Zigbee worker then proceeds without waiting for Thread
-	  or DNS-SD. Set CONFIG_CHIP_ENABLE_PAIRING_AUTOSTART=n if Matter
-	  commissioning over BLE is not needed until after a protocol switch.
+	  When disabled, the Zigbee worker is unblocked from within
+	  zigbee_matter_coexistence_on_server_started() without waiting
+	  for Thread or DNS-SD. Set CONFIG_CHIP_ENABLE_PAIRING_AUTOSTART=n
+	  if Matter commissioning over BLE is not needed until after a
+	  protocol switch.
 
 config ZIGBEE_MATTER_COEXISTENCE_BUTTON_SWITCH
 	bool "Enable user protocol switch on button long press"

--- a/subsys/lib/zigbee_matter_coexistence/coexistence.cpp
+++ b/subsys/lib/zigbee_matter_coexistence/coexistence.cpp
@@ -166,7 +166,7 @@ static void zboss_do_local_leave(zb_uint8_t param)
 	/* Sends a NWK Leave frame (notifying the coordinator to remove this
 	 * device from its tables, including the unique TCLK) and then erases
 	 * ZBOSS NVRAM.  The ZB_ZDO_SIGNAL_LEAVE signal fires when done, which
-	 * is forwarded to zigbee_matter_coexistence_on_zboss_leave_signal(). */
+	 * is forwarded via zigbee_matter_coexistence_handle_zboss_signal(). */
 	zb_bdb_reset_via_local_action(0);
 }
 
@@ -359,10 +359,31 @@ extern "C" int zigbee_matter_coexistence_run(const struct zigbee_matter_coexiste
 	return 0;
 }
 
-extern "C" void zigbee_matter_coexistence_on_zboss_leave_signal(void)
+static void on_zboss_leave_signal(void)
 {
 	if (atomic_get(&g_matter_switch_pending_leave)) {
 		k_sem_give(&leave_done_sem);
+	}
+}
+
+extern "C" void zigbee_matter_coexistence_handle_zboss_signal(zb_bufid_t bufid)
+{
+	if (!bufid) {
+		return;
+	}
+
+	zb_zdo_app_signal_hdr_t *sig_handler = nullptr;
+	const zb_zdo_app_signal_type_t sig = zb_get_app_signal(bufid, &sig_handler);
+
+	if (sig != ZB_ZDO_SIGNAL_LEAVE || ZB_GET_APP_SIGNAL_STATUS(bufid) != RET_OK) {
+		return;
+	}
+
+	zb_zdo_signal_leave_params_t *const leave_params =
+		ZB_ZDO_SIGNAL_GET_PARAMS(sig_handler, zb_zdo_signal_leave_params_t);
+
+	if (leave_params->leave_type == ZB_NWK_LEAVE_TYPE_RESET) {
+		on_zboss_leave_signal();
 	}
 }
 

--- a/subsys/lib/zigbee_matter_coexistence/coexistence.cpp
+++ b/subsys/lib/zigbee_matter_coexistence/coexistence.cpp
@@ -11,7 +11,13 @@
 #include <platform/CHIPDeviceLayer.h>
 #include <platform/ThreadStackManager.h>
 
+#if defined(CONFIG_OPENTHREAD)
+#include <openthread/dataset.h>
+#include <openthread/ip6.h>
+#endif
+
 #include <app/matter_event_handler.h>
+#include <app/server/Server.h>
 
 #include <net/nrf_802154_callbacks_dispatcher.h>
 
@@ -31,8 +37,10 @@ namespace
 const struct zigbee_matter_coexistence_callbacks *g_cb;
 
 K_SEM_DEFINE(matter_init_done_sem, 0, 1);
+K_SEM_DEFINE(leave_done_sem, 0, 1);
 
 atomic_t g_switch_press_active = ATOMIC_INIT(0);
+atomic_t g_matter_switch_pending_leave = ATOMIC_INIT(0);
 
 void switch_to_thread_radio(void);
 void switch_to_zigbee_radio(void);
@@ -40,6 +48,36 @@ void switch_to_zigbee_radio(void);
 void matter_board_init_signal(void)
 {
 	k_sem_give(&matter_init_done_sem);
+}
+
+void start_thread_network_if_commissioned(void)
+{
+#if defined(CONFIG_OPENTHREAD)
+	using namespace chip::DeviceLayer;
+
+	ThreadStackMgr().LockThreadStack();
+	otInstance *const instance = ThreadStackMgrImpl().OTInstance();
+	otError ot_err = OT_ERROR_NONE;
+	bool commissioned = false;
+
+	if (instance != nullptr) {
+		commissioned = otDatasetIsCommissioned(instance);
+		if (commissioned && otThreadGetDeviceRole(instance) == OT_DEVICE_ROLE_DISABLED) {
+			ot_err = otIp6SetEnabled(instance, true);
+			if (ot_err == OT_ERROR_NONE) {
+				ot_err = otThreadSetEnabled(instance, true);
+			}
+		}
+	}
+
+	ThreadStackMgr().UnlockThreadStack();
+
+	if (ot_err != OT_ERROR_NONE) {
+		LOG_ERR("Failed to start Thread after radio handover: %d", ot_err);
+	} else if (commissioned) {
+		LOG_INF("Thread network started after radio handover to OpenThread");
+	}
+#endif
 }
 
 void protocol_switch_work_handler(struct k_work *work)
@@ -89,6 +127,7 @@ void zigbee_thread_fn()
 
 		/* Still chain sample button handlers after Matter board init. */
 		(void)k_sem_take(&matter_init_done_sem, K_FOREVER);
+		start_thread_network_if_commissioned();
 		if (g_cb->post_matter_board_init != NULL) {
 			g_cb->post_matter_board_init();
 		}
@@ -121,8 +160,36 @@ K_THREAD_DEFINE(matter_thread_id, CONFIG_ZIGBEE_MATTER_COEXISTENCE_MATTER_THREAD
 		matter_thread_fn, NULL, NULL, NULL,
 		CONFIG_ZIGBEE_MATTER_COEXISTENCE_MATTER_THREAD_PRIORITY, 0, K_TICKS_FOREVER);
 
+static void zboss_do_local_leave(zb_uint8_t param)
+{
+	ZVUNUSED(param);
+	/* Sends a NWK Leave frame (notifying the coordinator to remove this
+	 * device from its tables, including the unique TCLK) and then erases
+	 * ZBOSS NVRAM.  The ZB_ZDO_SIGNAL_LEAVE signal fires when done, which
+	 * is forwarded to zigbee_matter_coexistence_on_zboss_leave_signal(). */
+	zb_bdb_reset_via_local_action(0);
+}
+
 void switch_to_thread_radio(void)
 {
+	/* Ask ZBOSS to send a clean NWK Leave frame so the coordinator removes
+	 * this device's unique TCLK.  We wait up to 5 s; after that we proceed
+	 * regardless (coordinator may be unreachable). */
+	atomic_set(&g_matter_switch_pending_leave, 1);
+	k_sem_reset(&leave_done_sem);
+	zb_ret_t zb_ret = zigbee_schedule_callback(zboss_do_local_leave, 0);
+	if (zb_ret == RET_OK) {
+		if (k_sem_take(&leave_done_sem, K_SECONDS(5)) != 0) {
+			LOG_WRN("Leave confirmation not received within timeout; "
+				"coordinator may be unreachable");
+			k_sem_reset(&leave_done_sem);
+		}
+	} else {
+		LOG_WRN("Failed to schedule ZBOSS leave callback (%d), proceeding without leave",
+			zb_ret);
+	}
+	atomic_set(&g_matter_switch_pending_leave, 0);
+
 	k_thread_abort(zigbee_thread_id);
 	zigbee_deinit();
 
@@ -131,6 +198,8 @@ void switch_to_thread_radio(void)
 
 	int ret = nrf_802154_callbacks_dispatcher_switch("openthread");
 	__ASSERT(ret == 0, "Failed to switch 802.15.4 radio to Thread: %d", ret);
+
+	start_thread_network_if_commissioned();
 }
 
 void switch_to_zigbee_radio(void)
@@ -152,10 +221,24 @@ void matter_event_handler(const chip::DeviceLayer::ChipDeviceEvent *event, intpt
 			matter_board_init_signal();
 		}
 		break;
+	case chip::DeviceLayer::DeviceEventType::kServerReady:
+		/*
+		 * Fallback when operational DNS-SD comes up. After switching back
+		 * to Zigbee, DNS-SD often stays disabled while Thread is deferred,
+		 * so app_task_matter also signals once StartServer() returns.
+		 */
+		if (protocol_state_get() == PROTOCOL_ZIGBEE &&
+		    chip::Server::GetInstance().GetFabricTable().FabricCount() > 0) {
+			matter_board_init_signal();
+		}
+		break;
 #endif /* CONFIG_ZIGBEE_MATTER_COEXISTENCE_BT_ADV_WHILE_ZIGBEE */
 	case chip::DeviceLayer::DeviceEventType::kSecureSessionEstablished:
-		if (protocol_state_get() == PROTOCOL_ZIGBEE &&
-		    !chip::DeviceLayer::ThreadStackMgr().IsThreadAttached()) {
+		if (protocol_state_get() == PROTOCOL_ZIGBEE
+#if defined(CONFIG_OPENTHREAD)
+		    && !chip::DeviceLayer::ThreadStackMgr().IsThreadAttached()
+#endif
+		) {
 			switch_to_thread_radio();
 		}
 		break;
@@ -193,6 +276,66 @@ extern "C" void zigbee_matter_coexistence_signal_matter_board_init(void)
 	matter_board_init_signal();
 }
 
+extern "C" void zigbee_matter_coexistence_on_server_started(void)
+{
+#if defined(CONFIG_OPENTHREAD)
+	/* Restore the 802.15.4 dispatcher to Zigbee now that Matter server init
+	 * (including InitThreadStack()) has completed.  pre_server_init() switched
+	 * it to OpenThread so the OT radio platform could initialise safely.
+	 * Also disable the OT IP6 interface so OT does not scan or transmit on the
+	 * 802.15.4 channel while Zigbee owns the radio. */
+	if (protocol_state_get() == PROTOCOL_ZIGBEE) {
+		using namespace chip::DeviceLayer;
+		ThreadStackMgr().LockThreadStack();
+		otInstance *const inst = ThreadStackMgrImpl().OTInstance();
+		if (inst != nullptr && otIp6IsEnabled(inst)) {
+			otIp6SetEnabled(inst, false);
+		}
+		ThreadStackMgr().UnlockThreadStack();
+
+		int ret = nrf_802154_callbacks_dispatcher_switch("zigbee");
+		if (ret != 0) {
+			LOG_ERR("Failed to restore radio dispatcher to Zigbee: %d", ret);
+		} else {
+			LOG_INF("Radio dispatcher restored to Zigbee after Matter server init");
+		}
+	}
+#endif
+
+#ifdef CONFIG_ZIGBEE_MATTER_COEXISTENCE_BT_ADV_WHILE_ZIGBEE
+	/* The Zigbee worker always waits on matter_init_done_sem, including in
+	 * the PROTOCOL_MATTER boot path (to synchronise with start_thread_network_if_commissioned).
+	 * In Zigbee mode with no fabrics the kCHIPoBLEAdvertisingChange event
+	 * unblocks the worker; in all other cases (Matter mode, or Zigbee mode
+	 * with existing fabrics that suppress advertising) signal explicitly. */
+	if (protocol_state_get() == PROTOCOL_MATTER ||
+	    chip::Server::GetInstance().GetFabricTable().FabricCount() > 0) {
+		matter_board_init_signal();
+	}
+#else
+	matter_board_init_signal();
+#endif
+}
+
+extern "C" void zigbee_matter_coexistence_pre_server_init(void)
+{
+#if defined(CONFIG_OPENTHREAD)
+	/* Switch the 802.15.4 dispatcher to OpenThread so that InitThreadStack()
+	 * can initialise the OT radio platform (otPlatRadioInit / nrf_802154_init)
+	 * without crashing.  Zigbee loses radio callbacks for the duration of
+	 * StartServer(); on_server_started() switches the dispatcher back. */
+	if (protocol_state_get() == PROTOCOL_ZIGBEE) {
+		int ret = nrf_802154_callbacks_dispatcher_switch("openthread");
+		if (ret != 0) {
+			LOG_ERR("Failed to switch radio dispatcher to OpenThread: %d", ret);
+		} else {
+			LOG_INF("Radio dispatcher switched to OpenThread for Matter server init");
+		}
+	}
+#endif
+}
+
+
 extern "C" int zigbee_matter_coexistence_run(const struct zigbee_matter_coexistence_callbacks *cb)
 {
 	__ASSERT(cb != NULL, "Null callback table");
@@ -214,6 +357,13 @@ extern "C" int zigbee_matter_coexistence_run(const struct zigbee_matter_coexiste
 	k_thread_start(matter_thread_id);
 
 	return 0;
+}
+
+extern "C" void zigbee_matter_coexistence_on_zboss_leave_signal(void)
+{
+	if (atomic_get(&g_matter_switch_pending_leave)) {
+		k_sem_give(&leave_done_sem);
+	}
 }
 
 extern "C" bool zigbee_matter_coexistence_process_switch_button(uint32_t button_state,


### PR DESCRIPTION
A bus fault in the openthread thread was triggered when InitThreadStack() auto-started the radio stack while Zigbee still owned the 802.15.4 radio. Disable CHIP_DEVICE_CONFIG_ENABLE_THREAD_AUTOSTART via a CMake compile definition so OpenThread never starts autonomously; the coexistence runtime starts Thread explicitly once the radio dispatcher is handed over.

On the Matter→Zigbee switch, kill ZBOSS only after sending a clean NWK Leave so the coordinator removes the device's unique TCLK entry.  This prevents the fresh-join TCLK mismatch that caused the coordinator to fail the Transport-Key delivery after the next reboot.