### PR TITLE
subsys: enable Zigbee R22 behavior by default

### DIFF
--- a/docs/configuring.rst
+++ b/docs/configuring.rst
@@ -77,6 +77,25 @@ Optional configuration
 
 After enabling the Zigbee protocol and defining the Zigbee device role, you can enable additional options in Kconfig and modify `ZBOSS stack start options`_.
 
+.. _zigbee_ug_r22_behavior:
+
+Zigbee PRO core runtime behavior (R22 or R23 mode)
+==================================================
+
+The ZBOSS stack in the |addon| implements Zigbee PRO R23, but CSA requires Zigbee 3.0 products to run the core in R22 behavior mode during product certification.
+See :ref:`zboss_certification_r22_mode` for the certification background.
+
+By default, the add-on selects R22 mode (``CONFIG_ZIGBEE_PRO_CORE_BEHAVIOR_R22``).
+When you call :c:func:`zigbee_enable`, the OSIF layer invokes :c:func:`zboss_use_r22_behavior` before the ZBOSS thread starts.
+The stack then uses classic R22 joining (association and transport-key flow) instead of native R23 behavior (Network Commissioning followed by Dynamic Link Key negotiation).
+
+To keep native R23 behavior, select R23 mode (``CONFIG_ZIGBEE_PRO_CORE_BEHAVIOR_R23``) in the Zigbee PRO core runtime behavior Kconfig choice.
+Use R23 mode only for evaluation of R23-specific features; it is not suitable for Zigbee 3.0 product certification.
+
+This Kconfig choice is not available when building with ``CONFIG_ZIGBEE_LIBRARY_NCP_DEV`` (NCP development libraries).
+
+For the underlying ZBOSS API, see `Runtime switch of R23 ZBOSS into R22 mode`_ in the ZBOSS API documentation.
+
 Device operational channel
 ==========================
 

--- a/docs/includes/zigbee_r22_certification_note.txt
+++ b/docs/includes/zigbee_r22_certification_note.txt
@@ -1,0 +1,10 @@
+.. note::
+   Zigbee 3.0 product certification requires R22 mode on R23 platforms.
+
+   The Connectivity Standards Alliance (CSA) requires that Zigbee 3.0 devices built on Zigbee PRO R23 or R23.2 platforms run the core stack in R22 behavior mode during product certification.
+   In this mode, the stack disables R23-specific features (such as TLV-based ZDO, Network Commissioning, and Dynamic Link Key negotiation) and reports revision R22 in the Node descriptor.
+
+   The |addon| enables R22 mode by default.
+   The OSIF layer calls :c:func:`zboss_use_r22_behavior` from :c:func:`zigbee_enable` before the ZBOSS thread starts.
+   To use native R23 behavior instead, select R23 mode (``CONFIG_ZIGBEE_PRO_CORE_BEHAVIOR_R23``) in Kconfig.
+   See :ref:`zigbee_ug_r22_behavior` and :ref:`zboss_certification_r22_mode` for details.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -10,6 +10,8 @@ The |addon| for the |NCS| provides support for developing Zigbee applications ba
 This stack is included as the :ref:`zigbee_zboss` library (version |zboss_version|).
 In combination with the |NCS|, the |addon| allows for development of low-power connected solutions.
 
+.. include:: /includes/zigbee_r22_certification_note.txt
+
 .. toctree::
    :maxdepth: 1
    :caption: Contents

--- a/docs/lib/osif.rst
+++ b/docs/lib/osif.rst
@@ -54,6 +54,9 @@ You can also configure the following OSIF-related Kconfig options:
   Must be lower than ``CONFIG_ZBOSS_INIT_PRIORITY`` so the radio is ready before ZBOSS starts.
 * ``CONFIG_ZBOSS_INIT_PRIORITY`` - Initialization priority for the ZBOSS stack.
   Must be higher than ``CONFIG_ZBOSS_RADIO_INIT_PRIORITY``.
+* ``CONFIG_ZIGBEE_PRO_CORE_BEHAVIOR_R22`` / ``CONFIG_ZIGBEE_PRO_CORE_BEHAVIOR_R23`` - Selects if :c:func:`zigbee_enable` calls :c:func:`zboss_use_r22_behavior` before starting the ZBOSS thread.
+  R22 mode is selected by default and is required for Zigbee 3.0 product certification.
+  See :ref:`zigbee_ug_r22_behavior`.
 
 Additionally, the following Kconfig option is available when setting :ref:`zigbee_ug_logging_logger_options`:
 

--- a/docs/zboss/certification.rst
+++ b/docs/zboss/certification.rst
@@ -28,6 +28,46 @@ The certification guarantees that a platform or product will work and will inter
 Nordic Semiconductor provides the Zigbee Compliant Platform.
 You can use this platform as the building block for your Zigbee Certified Product, which is conformant with the ZCL and BDB standard.
 
+.. _zboss_certification_r22_mode:
+
+R22 behavior mode for Zigbee 3.0 product certification
+******************************************************
+
+This page explains why Zigbee 3.0 products built on the Zigbee PRO R23 and R23.2 platforms must run the core stack in R22 behavior mode during certification, and how the |addon| applies this mode by default.
+
+.. include:: /includes/zigbee_r22_certification_note.txt
+
+CSA certification policy for Zigbee 3.0 products on R23 platforms
+=================================================================
+
+The Zigbee PRO R23 and R23.2 platform in the |addon| is certified in native R23 mode.
+MAC-layer certification does not depend on the R22 or R23 runtime mode.
+
+For Zigbee 3.0 product certification, CSA requires the R23 core to run in R22 behavior mode.
+As of late 2025, the PRO Core TSG determined that Zigbee 3.0 devices based on the R23 stack must operate the core in R22 mode (originally defined for Test Harness use in the R23 Platform Test Specification).
+The same requirement applies to both R23 and R23.2 specification versions.
+
+R22 behavior mode is therefore the default in the |addon|.
+The add-on applies it automatically through the Zigbee PRO core runtime behavior Kconfig choice (``CONFIG_ZIGBEE_PRO_CORE_BEHAVIOR_R22``).
+See :ref:`zigbee_ug_r22_behavior` for configuration details.
+
+When certifying a Zigbee 3.0 product, declare R23.2 as the core version.
+The certification procedure and test set are unchanged.
+Only the application must run in R22 mode.
+
+R22 mode and full Zigbee PRO R22 conformance
+============================================
+
+On ZBOSS 4.x and 5.x, R22 behavior mode satisfies CSA requirements for Zigbee 3.0 device certification, but does not provide full conformance to the Zigbee PRO Core R22 specification.
+
+R22 behavior mode has the following known deviations from the Zigbee PRO Core R22 specification:
+
+* The APS fragmentation window is always set to 1, while R22 allows larger values.
+* Automatic PAN ID conflict resolution is not performed. 
+  The application is notified when a conflict is detected (R22 requires automatic resolution).
+
+After enabling R22 mode, DSR recommends running your product application through ZUTH certification tests before submitting for product certification.
+
 Certification IDs
 *****************
 

--- a/subsys/Kconfig
+++ b/subsys/Kconfig
@@ -422,6 +422,30 @@ config ZIGBEE_TC_REJOIN_ENABLED
 	bool "Enables Trust Center Rejoin"
 	default y
 
+choice ZIGBEE_PRO_CORE_BEHAVIOR
+	prompt "Zigbee PRO core runtime behavior"
+	depends on !ZIGBEE_LIBRARY_NCP_DEV
+	default ZIGBEE_PRO_CORE_BEHAVIOR_R22
+
+config ZIGBEE_PRO_CORE_BEHAVIOR_R22
+	bool "R22 mode"
+	help
+	  The add-on calls zboss_use_r22_behavior() from zigbee_enable(),
+	  before the ZBOSS thread is started. The stack uses legacy R22
+	  joining (classic association and transport-key flow).
+
+	  R22 mode is required to certify a Zigbee 3.0 product on an
+	  R23-compliant platform.
+
+config ZIGBEE_PRO_CORE_BEHAVIOR_R23
+	bool "R23 mode"
+	help
+	  The stack keeps the native R23 behavior (NWK Commissioning
+	  followed by Dynamic Link Key negotiation). This mode is not
+	  suitable for Zigbee 3.0 product certification on R23 platforms.
+
+endchoice
+
 config ZIGBEE_DEV_REJOIN_TIMEOUT_MS
 	int "Timeout in ms after which End Device stops to send beacons if can not join/rejoin a network"
 	default 200000

--- a/subsys/osif/zb_nrf_platform.c
+++ b/subsys/osif/zb_nrf_platform.c
@@ -741,6 +741,10 @@ uint32_t zigbee_event_poll(uint32_t timeout_us)
 
 void zigbee_enable(void)
 {
+#if IS_ENABLED(CONFIG_ZIGBEE_PRO_CORE_BEHAVIOR_R22)
+	zboss_use_r22_behavior();
+#endif
+
 	zboss_tid = k_thread_create(&zboss_thread_data,
 				    zboss_stack_area,
 				    K_THREAD_STACK_SIZEOF(zboss_stack_area),


### PR DESCRIPTION
Add a Kconfig choice to select Zigbee PRO core runtime behavior (R22 or R23). R22 mode is the default and calls zboss_use_r22_behavior() from zigbee_enable() before the ZBOSS thread starts, as required for Zigbee 3.0 product certification on R23 platforms.