### PR TITLE
samples: Fix handling PWM in Zigbee+Matter Light Bulb

### DIFF
--- a/samples/light_bulb/CMakeLists.txt
+++ b/samples/light_bulb/CMakeLists.txt
@@ -37,6 +37,7 @@ if(CONFIG_CHIP)
         src/main.cpp
         src/app_task_zigbee.cpp
         src/app_task_matter.cpp
+        src/zcl_callbacks.cpp
         ${CHIP_ROOT}/src/app/persistence/DeferredAttributePersistenceProvider.cpp
     )
     

--- a/samples/light_bulb/src/app_task_zigbee.cpp
+++ b/samples/light_bulb/src/app_task_zigbee.cpp
@@ -445,7 +445,7 @@ static void bulb_clusters_attr_init(void) {
       ZB_ZCL_IDENTIFY_IDENTIFY_TIME_DEFAULT_VALUE;
 
   /* On/Off cluster attributes data. */
-  dev_ctx.on_off_attr.on_off = (zb_bool_t)ZB_ZCL_ON_OFF_IS_ON;
+  dev_ctx.on_off_attr.on_off = (zb_bool_t)ZB_ZCL_ON_OFF_IS_OFF;
 
   dev_ctx.level_control_attr.current_level =
       ZB_ZCL_LEVEL_CONTROL_LEVEL_MAX_VALUE;
@@ -630,7 +630,12 @@ extern "C" int ZigbeeStart(void) {
   ZB_AF_REGISTER_DEVICE_CTX(&dimmable_light_ctx);
 
   bulb_clusters_attr_init();
-  level_control_set_value(dev_ctx.level_control_attr.current_level);
+
+  if (dev_ctx.on_off_attr.on_off) {
+    level_control_set_value(dev_ctx.level_control_attr.current_level);
+  } else {
+    level_control_set_value(0U);
+  }
 
 #if defined(CONFIG_ZIGBEE_FOTA) || defined(CONFIG_ZIGBEE_BT_DFU)
   confirm_image();

--- a/samples/light_bulb/src/zcl_callbacks.cpp
+++ b/samples/light_bulb/src/zcl_callbacks.cpp
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include <lib/support/logging/CHIPLogging.h>
+
+#include "app_task_matter.h"
+
+#include <app-common/zap-generated/attributes/Accessors.h>
+#include <app-common/zap-generated/ids/Attributes.h>
+#include <app-common/zap-generated/ids/Clusters.h>
+#include <app/ConcreteAttributePath.h>
+
+using namespace ::chip;
+using namespace ::chip::app::Clusters;
+using namespace ::chip::app::Clusters::OnOff;
+
+void MatterPostAttributeChangeCallback(const chip::app::ConcreteAttributePath &attributePath, uint8_t type,
+				       uint16_t size, uint8_t *value)
+{
+	(void)type;
+	(void)size;
+
+	ClusterId clusterId = attributePath.mClusterId;
+	AttributeId attributeId = attributePath.mAttributeId;
+
+	if (clusterId == OnOff::Id && attributeId == OnOff::Attributes::OnOff::Id) {
+		ChipLogProgress(Zcl, "Cluster OnOff: attribute OnOff set to %" PRIu8 "", *value);
+
+#if defined(CONFIG_PWM)
+		AppTask::Instance().GetPWMDevice().InitiateAction(*value ? Nrf::PWMDevice::ON_ACTION :
+									   Nrf::PWMDevice::OFF_ACTION,
+								  static_cast<int32_t>(LightingActor::Remote), value);
+#else
+		Nrf::GetBoard().GetLED(Nrf::DeviceLeds::LED2).Set(*value);
+#endif
+
+	} else if (clusterId == LevelControl::Id && attributeId == LevelControl::Attributes::CurrentLevel::Id) {
+		ChipLogProgress(Zcl, "Cluster LevelControl: attribute CurrentLevel set to %" PRIu8 "", *value);
+#if defined(CONFIG_PWM)
+		if (AppTask::Instance().GetPWMDevice().IsTurnedOn()) {
+			AppTask::Instance().GetPWMDevice().InitiateAction(
+				Nrf::PWMDevice::LEVEL_ACTION, static_cast<int32_t>(LightingActor::Remote), value);
+		} else {
+			ChipLogDetail(Zcl, "LED is off. Try to use move-to-level-with-on-off instead of move-to-level");
+		}
+#endif
+	}
+}
+
+/** @brief OnOff Cluster Init
+ *
+ * This function is called when a specific cluster is initialized. It gives the
+ * application an opportunity to take care of cluster initialization procedures.
+ * It is called exactly once for each endpoint where cluster is present.
+ *
+ * @param endpoint   Ver.: always
+ *
+ * TODO Issue #3841
+ * emberAfOnOffClusterInitCallback happens before the stack initialize the cluster
+ * attributes to the default value.
+ * The logic here expects something similar to the deprecated Plugins callback
+ * emberAfPluginOnOffClusterServerPostInitCallback.
+ *
+ */
+void emberAfOnOffClusterInitCallback(EndpointId endpoint)
+{
+	Protocols::InteractionModel::Status status;
+	bool storedValue;
+
+	ChipLogDetail(Zcl, "OnOff Cluster initialization callback for endpoint %" PRIu16, endpoint);
+
+	/* Read storedValue on/off value */
+	status = Attributes::OnOff::Get(endpoint, &storedValue);
+
+	if (status == Protocols::InteractionModel::Status::Success) {
+		/* Set actual state to the cluster state that was last persisted */
+#if defined(CONFIG_PWM)
+		AppTask::Instance().InitPWMDDevice();
+
+		AppTask::Instance().GetPWMDevice().InitiateAction(
+			storedValue ? Nrf::PWMDevice::ON_ACTION : Nrf::PWMDevice::OFF_ACTION,
+			static_cast<int32_t>(LightingActor::Remote), nullptr);
+#else
+		Nrf::GetBoard().GetLED(Nrf::DeviceLeds::LED2).Set(storedValue);
+#endif
+	} else {
+		ChipLogError(Zcl, "Failed to read stored OnOff value: 0x%x", to_underlying(status));
+	}
+
+	ChipLogDetail(Zcl, "Updating cluster state after OnOff Cluster Init");
+	AppTask::Instance().UpdateClusterState();
+}


### PR DESCRIPTION
The Matter Data Model callbacks were missing in the Light Bulb sample which caused that the state was changed only in the cluster server, but it was not set on LED.