### PR TITLE
doc: extend list of supported devices for Zigbee FOTA

### DIFF
--- a/docs/lib/zigbee_fota.rst
+++ b/docs/lib/zigbee_fota.rst
@@ -105,7 +105,7 @@ The Zigbee FOTA library has the following limitations:
 
 * The endpoint definition in the library includes the endpoint ID, defined with ``CONFIG_ZIGBEE_FOTA_ENDPOINT``.
   When using the Zigbee FOTA library, this endpoint ID cannot be used for other endpoints.
-* The Zigbee FOTA upgrades are currently supported on the nRF52840 DK (PCA10056), nRF5340 DK (PCA10095) and nRF54L15 DK (PCA10156).
+* The Zigbee FOTA upgrades are currently supported on the nRF52840 DK (PCA10056), nRF5340 DK (PCA10095), nRF54L15 DK (PCA10156), and nRF54LM20 DK (PCA10157).
 * The Zigbee FOTA library does not currently support bootloader upgrades.
 
 Additionally, the following limitations apply on the nRF5340 SoCs:


### PR DESCRIPTION
nRF54LM20 DK was missing.