### PR TITLE
subsys: reduce flash operations during ZBOSS NVRAM storage

### DIFF
--- a/docs/release-notes.rst
+++ b/docs/release-notes.rst
@@ -39,6 +39,16 @@ For a full list of |addon| releases, related |NCS| and ZBOSS stack and NCP host 
 | 0.1.0             |                  |                       | N/A                 | 
 +-------------------+------------------+-----------------------+---------------------+
 
+|addon| vX.Y.Z - TBD
+***************************
+
+The following release is `supported <Software maturity levels_>`_.
+
+* Updated:
+
+  * Improved ZBOSS NVRAM storage by batching flash writes into fewer operations.
+    Cache size is controlled by ``CONFIG_ZIGBEE_NVRAM_WRITE_CACHE_SIZE``.
+
 .. _zigbee_release:
 
 |addon| v1.4.0 - 04/08/2026

--- a/scripts/ci/sample_build_plan.yaml
+++ b/scripts/ci/sample_build_plan.yaml
@@ -19,7 +19,7 @@ twister:
 
 # Scenarios always included in PR builds (in addition to path trigger matches).
 # The scenarios here must reflect the integration scope of the project.
-# platform: [] or omitted means all platforms allowed by the scenario in sample.yaml.
+# platform: [] or omitted means all integration_platforms from sample.yaml for that scenario.
 always_build:
   - scenario: template
     platform:
@@ -36,6 +36,7 @@ full_build_paths:
   - lib/**
 
 # Map changed paths to one or more samples/variants/platforms.
+# Each scenario/variant platform list must be a subset of integration_platforms in that sample's sample.yaml.
 path_triggers:
   # ---------------------------------------------------------------------------
   # Sample path triggers
@@ -70,6 +71,7 @@ path_triggers:
           - multiprotocol
         platform:
           - nrf5340dk/nrf5340/cpuapp
+          - nrf54l15dk/nrf54l15/cpuapp
           - nrf54lm20dk/nrf54lm20b/cpuapp
 
   light-switch-fota:
@@ -81,11 +83,14 @@ path_triggers:
           - fota
         platform:
           - nrf52840dk/nrf52840
+          - nrf54l15dk/nrf54l15/cpuapp
           - nrf54lm20dk/nrf54lm20b/cpuapp
       - scenario: light_switch
         variants:
           - fota_and_multiprotocol
         platform:
+          - nrf5340dk/nrf5340/cpuapp
+          - nrf54l15dk/nrf54l15/cpuapp
           - nrf54lm20dk/nrf54lm20b/cpuapp
 
   light-switch-low-power:
@@ -97,6 +102,8 @@ path_triggers:
           - low_power
         platform:
           - nrf52840dk/nrf52840
+          - nrf5340dk/nrf5340/cpuapp
+          - nrf54l15dk/nrf54l15/cpuapp
           - nrf54lm20dk/nrf54lm20b/cpuapp
 
   ncp-sample:
@@ -112,6 +119,7 @@ path_triggers:
         variants:
           - usb
         platform:
+          - nrf52833dk/nrf52833
           - nrf52840dk/nrf52840
       - scenario: ncp
         variants:
@@ -126,6 +134,7 @@ path_triggers:
       - scenario: network_coordinator
         platform:
           - nrf5340dk/nrf5340/cpuapp
+          - nrf54l15dk/nrf54l15/cpuapp
           - nrf54lm20dk/nrf54lm20b/cpuapp
 
   shell-sample:
@@ -135,12 +144,15 @@ path_triggers:
       - scenario: shell
         platform:
           - nrf52840dk/nrf52840
+          - nrf5340dk/nrf5340/cpuapp
+          - nrf54l15dk/nrf54l15/cpuapp
           - nrf54lm20dk/nrf54lm20b/cpuapp
       - scenario: shell
         variants:
           - usb
         platform:
           - nrf52840dongle/nrf52840
+          - nrf5340dk/nrf5340/cpuapp
           - nrf54lm20dk/nrf54lm20b/cpuapp
 
   template-sample:
@@ -170,6 +182,7 @@ path_triggers:
           - fota
         platform:
           - nrf52840dk/nrf52840
+          - nrf54l15dk/nrf54l15/cpuapp
           - nrf54lm20dk/nrf54lm20b/cpuapp
 
   # ---------------------------------------------------------------------------
@@ -182,10 +195,12 @@ path_triggers:
       - subsys/osif/**
       - subsys/partition_manager/**
     samples:
-      - scenario: template
+      - scenario: light_bulb
         platform:
           - nrf52840dk/nrf52840
           - nrf5340dk/nrf5340/cpuapp
+      - scenario: light_switch
+        platform:
           - nrf54l15dk/nrf54l15/cpuapp
           - nrf54lm20dk/nrf54lm20b/cpuapp
 
@@ -202,7 +217,9 @@ path_triggers:
         variants:
           - fota
         platform:
+          - nrf52840dk/nrf52840
           - nrf54l15dk/nrf54l15/cpuapp
+          - nrf54lm20dk/nrf54lm20b/cpuapp
 
   subsys-lib-zigbee-bt-dfu:
     paths:
@@ -246,11 +263,6 @@ path_triggers:
       - subsys/lib/zigbee_shell/**
     samples:
       - scenario: shell
-        platform:
-          - nrf54lm20dk/nrf54lm20b/cpuapp
-      - scenario: light_switch
-        variants:
-          - with_shell
         platform:
           - nrf54lm20dk/nrf54lm20b/cpuapp
 

--- a/subsys/Kconfig
+++ b/subsys/Kconfig
@@ -406,6 +406,25 @@ config ZIGBEE_NVRAM_PAGE_SIZE
 	int "The size of a single ZBOSS NVRAM page"
 	default 512
 
+config ZIGBEE_NVRAM_WRITE_CACHE_SIZE
+	int "Size of the ZBOSS NVRAM write cache"
+	default 512 if SOC_FLASH_NRF_RADIO_SYNC_MPSL || SOC_FLASH_NRF_RADIO_SYNC_RPC
+	default 0
+	help
+	  ZBOSS stores a dataset as a long sequence of small, contiguous writes and
+	  marks its end by calling zb_osif_nvram_flush(). Consecutive writes are
+	  gathered in a RAM cache of this size and committed to flash as a single
+	  operation, which matters on SoCs where each flash operation has to be
+	  arbitrated against the radio: paying that cost once per dataset instead of
+	  once per field keeps the radio available, so a parent device does not miss
+	  MAC acknowledgments while storing a child that has just joined.
+	  This is why the cache is enabled by default only where flash writes are
+	  synchronized with the radio; where they are not, such as on a SoC that
+	  runs the radio on a separate core, a write costs tens of microseconds and
+	  the cache would only spend RAM.
+	  Writes that do not continue the cached range, and writes that do not fit
+	  in the cache, commit the cache first. Set to 0 to write directly to flash.
+
 config ZIGBEE_TOUCHLINK_INITIATOR
 	bool "Enable Touchlink initiator role [EXPERIMENTAL]"
 	select EXPERIMENTAL

--- a/subsys/osif/zb_nrf_nvram.c
+++ b/subsys/osif/zb_nrf_nvram.c
@@ -44,6 +44,10 @@ BUILD_ASSERT(FIXED_PARTITION_EXISTS(zboss_product_config),
 #define PHYSICAL_PAGE_SIZE 0x1000
 BUILD_ASSERT((ZBOSS_NVRAM_PAGE_SIZE % PHYSICAL_PAGE_SIZE) == 0,
 	     "The size must be a multiply of physical page size.");
+#if CONFIG_ZIGBEE_NVRAM_WRITE_CACHE_SIZE > 0
+BUILD_ASSERT(CONFIG_ZIGBEE_NVRAM_WRITE_CACHE_SIZE <= ZBOSS_NVRAM_PAGE_SIZE,
+	     "ZIGBEE_NVRAM_WRITE_CACHE_SIZE must not exceed a ZBOSS NVRAM page");
+#endif
 
 LOG_MODULE_DECLARE(zboss_osif, CONFIG_ZBOSS_OSIF_LOG_LEVEL);
 
@@ -168,6 +172,86 @@ static int nvram_flash_write(const struct flash_area *area, off_t off,
 	return 0;
 }
 
+#if CONFIG_ZIGBEE_NVRAM_WRITE_CACHE_SIZE > 0
+
+/* ZBOSS stores a dataset as a sequence of small writes that continue each other and
+ * calls zb_osif_nvram_flush() once the dataset is complete, so consecutive writes are
+ * gathered here and committed as one flash operation.
+ */
+static struct {
+	zb_uint8_t data[CONFIG_ZIGBEE_NVRAM_WRITE_CACHE_SIZE];
+	zb_uint8_t page;
+	zb_uint32_t pos;
+	size_t len;
+} write_cache;
+
+/* Note: a dataset is committed from zb_osif_nvram_flush(), which cannot report
+ * failures back to ZBOSS, so a commit error is logged here as well.
+ */
+static int write_cache_commit(void)
+{
+	int err;
+
+	if (write_cache.len == 0) {
+		return 0;
+	}
+
+	err = nvram_flash_write(fa, get_page_base_offset(write_cache.page) + write_cache.pos,
+				write_cache.data, write_cache.len);
+	if (err) {
+		LOG_ERR("Cached write error: %d", err);
+		return err;
+	}
+
+	write_cache.len = 0;
+
+	return 0;
+}
+
+static bool write_cache_continues(zb_uint8_t page, zb_uint32_t pos, zb_uint16_t len)
+{
+	return (write_cache.len != 0) && (write_cache.page == page) &&
+	       (pos == write_cache.pos + write_cache.len) &&
+	       (write_cache.len + len <= sizeof(write_cache.data));
+}
+
+static int write_cache_add(zb_uint8_t page, zb_uint32_t pos, const void *buf, zb_uint16_t len)
+{
+	if (!write_cache_continues(page, pos, len)) {
+		int err = write_cache_commit();
+
+		if (err) {
+			return err;
+		}
+
+		if (len > sizeof(write_cache.data)) {
+			return nvram_flash_write(fa, get_page_base_offset(page) + pos, buf, len);
+		}
+
+		write_cache.page = page;
+		write_cache.pos = pos;
+	}
+
+	memcpy(write_cache.data + write_cache.len, buf, len);
+	write_cache.len += len;
+
+	return 0;
+}
+
+#else /* CONFIG_ZIGBEE_NVRAM_WRITE_CACHE_SIZE > 0 */
+
+static int write_cache_commit(void)
+{
+	return 0;
+}
+
+static int write_cache_add(zb_uint8_t page, zb_uint32_t pos, const void *buf, zb_uint16_t len)
+{
+	return nvram_flash_write(fa, get_page_base_offset(page) + pos, buf, len);
+}
+
+#endif /* CONFIG_ZIGBEE_NVRAM_WRITE_CACHE_SIZE > 0 */
+
 zb_ret_t zb_osif_nvram_read(zb_uint8_t page, zb_uint32_t pos, zb_uint8_t *buf,
 			    zb_uint16_t len)
 {
@@ -191,6 +275,11 @@ zb_ret_t zb_osif_nvram_read(zb_uint8_t page, zb_uint32_t pos, zb_uint8_t *buf,
 
 	uint32_t flash_addr = get_page_base_offset(page) + pos;
 
+	/* Make cached writes visible to the reader. */
+	if (write_cache_commit()) {
+		return RET_ERROR;
+	}
+
 	int err = flash_area_read(fa, flash_addr, buf, len);
 
 	if (err) {
@@ -203,8 +292,6 @@ zb_ret_t zb_osif_nvram_read(zb_uint8_t page, zb_uint32_t pos, zb_uint8_t *buf,
 zb_ret_t zb_osif_nvram_write(zb_uint8_t page, zb_uint32_t pos, void *buf,
 			     zb_uint16_t len)
 {
-	uint32_t flash_addr = get_page_base_offset(page) + pos;
-
 	if (page >= zb_get_nvram_page_count()) {
 		return RET_PAGE_NOT_FOUND;
 	}
@@ -228,7 +315,7 @@ zb_ret_t zb_osif_nvram_write(zb_uint8_t page, zb_uint32_t pos, void *buf,
 	LOG_DBG("Function: %s, page: %d, pos: %d, len: %d",
 		__func__, page, pos, len);
 
-	int err = nvram_flash_write(fa, flash_addr, buf, len);
+	int err = write_cache_add(page, pos, buf, len);
 
 	if (err) {
 		LOG_ERR("Write error: %d", err);
@@ -241,6 +328,10 @@ zb_ret_t zb_osif_nvram_write(zb_uint8_t page, zb_uint32_t pos, void *buf,
 zb_ret_t zb_osif_nvram_erase_async(zb_uint8_t page)
 {
 	zb_ret_t ret = RET_OK;
+
+	if (write_cache_commit()) {
+		ret = RET_ERROR;
+	}
 
 	if (page < zb_get_nvram_page_count()) {
 		int err = flash_area_erase(fa, get_page_base_offset(page),
@@ -256,12 +347,12 @@ zb_ret_t zb_osif_nvram_erase_async(zb_uint8_t page)
 
 void zb_osif_nvram_wait_for_last_op(void)
 {
-	/* empty for synchronous erase and write */
+	(void)write_cache_commit();
 }
 
 void zb_osif_nvram_flush(void)
 {
-	/* empty for synchronous erase and write */
+	(void)write_cache_commit();
 }
 
 

--- a/subsys/osif/zb_nrf_nvram.c
+++ b/subsys/osif/zb_nrf_nvram.c
@@ -99,29 +99,32 @@ static int nvram_flash_write(const struct flash_area *area, off_t off,
 	uint8_t block_buf[NVRAM_MAX_WRITE_BLOCK_SIZE];
 	int err;
 
+	/* Trivial case: alignment does not matter. */	
 	if (write_block <= 1) {
 		return flash_area_write(area, off, data, len);
 	}
 
 	__ASSERT_NO_MSG(write_block <= sizeof(block_buf));
 
-	while (len > 0) {
+	/* Unaligned start: flash requires writes on block boundaries (4 B or 16 B).
+	 Read-modify-write one block.
+	 */
+	if (off & (write_block - 1)) {
 		off_t block_start = off & ~(write_block - 1);
-		off_t block_off = off - block_start;
+		size_t block_off = off - block_start;
 		size_t chunk = MIN(len, write_block - block_off);
 
-		if (block_off == 0 && chunk == write_block) {
-			err = flash_area_write(area, block_start, src, write_block);
-		} else {
-			err = flash_area_read(area, block_start, block_buf, write_block);
-			if (err) {
-				return err;
-			}
-
-			memcpy(block_buf + block_off, src, chunk);
-			err = flash_area_write(area, block_start, block_buf, write_block);
+		/* Read the full block from flash. */
+		err = flash_area_read(area, block_start, block_buf, write_block);
+		if (err) {
+			return err;
 		}
 
+		/* Patch in the new bytes at the correct offset. */
+		memcpy(block_buf + block_off, src, chunk);
+
+		/* Write the whole block back. */
+		err = flash_area_write(area, block_start, block_buf, write_block);
 		if (err) {
 			return err;
 		}
@@ -129,6 +132,37 @@ static int nvram_flash_write(const struct flash_area *area, off_t off,
 		off += chunk;
 		src += chunk;
 		len -= chunk;
+	}
+
+	size_t aligned_len = len & ~((size_t)write_block - 1);
+
+	/* Aligned middle: write the largest contiguous aligned chunk in one
+	 * flash_area_write(). This avoids the need to read-modify-write multiple
+	 * blocks.
+	 */
+	if (aligned_len) {
+		err = flash_area_write(area, off, src, aligned_len);
+		if (err) {
+			return err;
+		}
+
+		off += aligned_len;
+		src += aligned_len;
+		len -= aligned_len;
+	}
+
+	/* Unaligned tail: same read-modify-write as the head. */
+	if (len) {
+		err = flash_area_read(area, off, block_buf, write_block);
+		if (err) {
+			return err;
+		}
+
+		memcpy(block_buf, src, len);
+		err = flash_area_write(area, off, block_buf, write_block);
+		if (err) {
+			return err;
+		}
 	}
 
 	return 0;


### PR DESCRIPTION
ZBOSS NVRAM storage issued too many small flash writes. This PR cuts that down in two ways:

- `nvram_flash_write()` — write the aligned middle of a buffer in one `flash_area_write()`, only the unaligned head and tail use read-modify-write.
- Write cache — gather consecutive `zb_osif_nvram_write()` calls and commit them on `zb_osif_nvram_flush()`.

Flash content and write order are unchanged. Cache size is controlled by `CONFIG_ZIGBEE_NVRAM_WRITE_CACHE_SIZE` (default 512 B; 0 on multiprotocol SoCs where flash is less contended).

