### PR TITLE
doc: Removed mentioning Kconfig search from NCS

### DIFF
--- a/docs/configuring.rst
+++ b/docs/configuring.rst
@@ -8,7 +8,6 @@ Configuring |addon|
    :depth: 2
 
 This page describes what is needed to start working with Zigbee using the |addon| for the |NCS|.
-|kconfig_search|
 
 .. _zigbee_ug_libs:
 

--- a/docs/configuring/configuring_libraries.rst
+++ b/docs/configuring/configuring_libraries.rst
@@ -10,8 +10,6 @@ Configuring Zigbee libraries
 The Zigbee protocol in the |addon| for the |NCS| can be customized by enabling and configuring several :ref:`Zigbee libraries <lib_zigbee>`.
 This page lists options and steps required for configuring each of them.
 
-|kconfig_search|
-
 .. _ug_zigbee_configuring_components_osif:
 
 Configuring ZBOSS OSIF

--- a/docs/shortcuts.txt
+++ b/docs/shortcuts.txt
@@ -29,9 +29,6 @@
 .. |sysbuild_autoenabled_ncs| replace:: When building `repository applications <Repository application_>`_ in the |addon| which is an `SDK repository <Repository types_>`_, building with sysbuild is `enabled by default <Sysbuild enabled by default_>`_.
    If you work with out-of-tree `freestanding applications <Freestanding application_>`_, you need to manually pass the ``--sysbuild`` parameter to every build command or `configure west to always use it <Configuring sysbuild usage in west_>`_.
 
-.. |kconfig_search| replace::
-   For details about the Kconfig options mentioned here, see the `Kconfig search`_ in the |NCS| documentation.
-
 .. ### Zigbee & ZBOSS shortcuts
 
 .. |zigbee_ncp_package_version| replace:: 3.7.0


### PR DESCRIPTION
Removed referring to Kconfig search from NCS documentation, because it simply does not work for Kconfigs defined in add-ons.